### PR TITLE
[ART] Fixed `encounters after death` pulling alive patients that don't have encounters after death.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ compatibility (examples of this include major architectural changes).
 
 - ART: Data cleaning tool, encounters after death, pulling patients that aren't dead or
   don't have encounters after death (EGPAF EMR Helpdesk #1977).
+- 422 Error on patient merge (EGPAF Helpdesk #1947)
 
 ## [4.10.22] - 2021-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ compatibility (examples of this include major architectural changes).
 
 - Global patient voiding (voids all of a patient's records)
 
+### Fixed
+
+- ART: Data cleaning tool, encounters after death, pulling patients that aren't dead or
+  don't have encounters after death (EGPAF EMR Helpdesk #1977).
+
 ## [4.10.22] - 2021-02-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ compatibility (examples of this include major architectural changes).
 - ART: Data cleaning tool, encounters after death, pulling patients that aren't dead or
   don't have encounters after death (EGPAF EMR Helpdesk #1977).
 - 422 Error on patient merge (EGPAF Helpdesk #1947)
+- ART: Data cleaning tool, encounters after death, pulling patients that aren't dead or
+  don't have encounters after death (EGPAF EMR Helpdesk #1977).
 
 ## [4.10.22] - 2021-02-12
 

--- a/app/models/concerns/voidable.rb
+++ b/app/models/concerns/voidable.rb
@@ -17,7 +17,7 @@ module Voidable
     clazz._update_voidable_field self, :void_reason, reason
     clazz._update_voidable_field self, :voided_by, user ? user.user_id : nil
 
-    save!
+    save!(validate: false)
 
     clazz._exec_after_void_callbacks self, reason unless skip_after_void
 

--- a/app/services/art_service/data_cleaning_tool.rb
+++ b/app/services/art_service/data_cleaning_tool.rb
@@ -372,6 +372,9 @@ EOF
           ON encounter.patient_id = deaths.patient_id
           AND encounter.encounter_datetime >= DATE(deaths.death_date) + INTERVAL 1 DAY
           AND encounter.program_id = 1
+          AND encounter.encounter_type NOT IN (
+            SELECT encounter_type_id FROM encounter_type WHERE name = 'HIV Reception'
+          )
         INNER JOIN person
           ON person.person_id = deaths.patient_id
         LEFT JOIN patient_identifier


### PR DESCRIPTION
- This fixes issue [#1977](https://egpafemr.sdpondemand.manageengine.com/app/itdesk/ui/requests/118246000003198035/details) on the helpdesk
- Query was retrieving patients that either aren't dead or have no encounters after death.