### PR TITLE
Fixed crash in after_void trigger on patient model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ compatibility (examples of this include major architectural changes).
 
 - Global patient voiding (voids all of a patient's records)
 
+### Fixed
+
+- 422 Error on patient merge (EGPAF Helpdesk #1947)
+
 ## [4.10.22] - 2021-02-12
 
 ### Fixed

--- a/app/models/concerns/voidable.rb
+++ b/app/models/concerns/voidable.rb
@@ -17,7 +17,7 @@ module Voidable
     clazz._update_voidable_field self, :void_reason, reason
     clazz._update_voidable_field self, :voided_by, user ? user.user_id : nil
 
-    save!
+    save!(validate: false)
 
     clazz._exec_after_void_callbacks self, reason unless skip_after_void
 


### PR DESCRIPTION
Validation on PatientIdentifier#belongs_to(:patient) was failing due not
being able to find the attached patient as it is called after patient is voided.