### PR TITLE
Fixed patient merging not appending secondary patient identifiers to primary patient.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ compatibility (examples of this include major architectural changes).
 
 ## [Unreleased]
 
+### Fixed
+
+- Patient merging not appending secondary patient identifiers to primary patient (helpdesk [#3541](https://egpafemr.sdpondemand.manageengine.com/app/itdesk/ui/requests/118246000006095075/details))
+
 ## [v4.11.13] - 2021-08-24
 
 ### Added


### PR DESCRIPTION
When two patients are merged it is expected that the secondary patient's
identifiers must be linked to the primary patient. In other words, searching
for a patient using the secondary patient's identifier must pull the primary
patient.

## Steps to reproduce

1. Create two patients: A and B
2. Copy patient's B National Health ID (NHID).
3. Merge the two patients
     - Patient A as primary
     - Patient B  as secondary
4. Use the copied NHID to search for the patient
     - Previously this resulted in no patients being found
     - After this update, the expected is the primary patient being returned.

This issue was reported through the helpdesk, can be viewed [here](https://egpafemr.sdpondemand.manageengine.com/app/itdesk/ui/requests/118246000006095075/details)
