### PR TITLE
Fixed active clients with adverse outcomes report crashing

### DIFF
--- a/app/services/art_service/reports/archiving_candidates.rb
+++ b/app/services/art_service/reports/archiving_candidates.rb
@@ -108,7 +108,7 @@ module ARTService
             INNER JOIN arv_drug
               ON arv_drug.drug_id = drug_order.drug_inventory_id
             WHERE orders.voided = 0
-              AND orders.patient_id NOT IN (#{patients_to_exclude.join(',')})
+              #{"AND orders.patient_id NOT IN (#{patients_to_exclude.join(',')})" unless patients_to_exclude.empty?}
             GROUP BY orders.patient_id
             LIMIT 100
           ) AS last_patient_drug_order


### PR DESCRIPTION
Report was crashing in cases where there are no patients with explicitly
set adverse outcomes in the database (eg Died, Treatment stopped, etc).
