### PR TITLE
[DDE] Fixed duplication of local dde patient when NPID is not matching DDE NPID

### DIFF
--- a/app/controllers/api/v1/dde_controller.rb
+++ b/app/controllers/api/v1/dde_controller.rb
@@ -50,7 +50,9 @@ class Api::V1::DdeController < ApplicationController
   # Updates local patient with demographics in DDE.
   def refresh_patient
     patient_id = params.require(:patient_id)
-    patient = service.update_local_patient(Patient.find(patient_id))
+    update_npid = params[:update_npid]&.casecmp?('true') || false
+
+    patient = service.update_local_patient(Patient.find(patient_id), update_npid: update_npid)
 
     render json: patient
   end

--- a/app/services/dde_merging_service.rb
+++ b/app/services/dde_merging_service.rb
@@ -88,9 +88,12 @@ class DDEMergingService
   end
 
   def local_patient_linked_to_remote?(local_patient, remote_patient)
-    identifier_exists = ->(type, value) { PatientIdentifierType.where(name: type), patient: patient, identifier: value).exists? }
+    identifier_exists = lambda do |type, value|
+      PatientIdentifier.where(patient: local_patient, type: PatientIdentifierType.where(name: type), identifier: value)
+                       .exists?
+    end
 
-    identifier_exists['National id'] && identifier_exists['DDE person document id']
+    identifier_exists['National id', remote_patient['npid']] && identifier_exists['DDE person document id', remote_patient['doc_id']]
   end
 
   private

--- a/app/services/dde_merging_service.rb
+++ b/app/services/dde_merging_service.rb
@@ -66,6 +66,8 @@ class DDEMergingService
   # Binds the remote patient to the local patient by blessing the local patient
   # with the remotes npid and doc_id
   def link_local_to_remote_patient(local_patient, remote_patient)
+    return local_patient if local_patient_linked_to_remote?(local_patient, remote_patient)
+
     national_id_type = patient_identifier_type('National id')
     doc_id_type = patient_identifier_type('DDE person document id')
 
@@ -83,6 +85,12 @@ class DDEMergingService
 
     local_patient.reload
     local_patient
+  end
+
+  def local_patient_linked_to_remote?(local_patient, remote_patient)
+    identifier_exists = ->(type, value) { PatientIdentifierType.where(name: type), patient: patient, identifier: value).exists? }
+
+    identifier_exists['National id'] && identifier_exists['DDE person document id']
   end
 
   private

--- a/app/services/dde_service.rb
+++ b/app/services/dde_service.rb
@@ -93,7 +93,7 @@ class DDEService
 
   ##
   # Updates local patient with demographics currently in DDE.
-  def update_local_patient(patient)
+  def update_local_patient(patient, update_npid: false)
     doc_id = patient_doc_id(patient)
     unless doc_id
       Rails.logger.warn("No DDE doc_id found for patient ##{patient.patient_id}")
@@ -108,9 +108,12 @@ class DDEService
       return patient
     end
 
-    person_service.update_person(patient.person, dde_patient_to_local_person(dde_patient))
-    merging_service.link_local_to_remote_patient(patient, dde_patient)
+    if update_npid
+      merging_service.link_local_to_remote_patient(patient, dde_patient)
+      return patient
+    end
 
+    person_service.update_person(patient.person, dde_patient_to_local_person(dde_patient))
     patient
   end
 

--- a/app/services/dde_service.rb
+++ b/app/services/dde_service.rb
@@ -109,6 +109,8 @@ class DDEService
     end
 
     person_service.update_person(patient.person, dde_patient_to_local_person(dde_patient))
+    merging_service.link_local_to_remote_patient(patient, dde_patient)
+
     patient
   end
 
@@ -312,9 +314,15 @@ class DDEService
                                 remote_patients: remote_patients,
                                 auto_push_singular_local: auto_push_singular_local)
 
-    patients[:remotes] = patients[:remotes].collect { |patient| localise_remote_patient(patient) }
+    # In some cases we may have remote patients that were previously imported but
+    # whose NPID has changed, we need to find and resolve these local patients.
+    unresolved_patients = find_patients_by_doc_id(patients[:remotes].collect { |remote_patient| remote_patient['doc_id'] })
+    additional_patients = resolve_patients(local_patients: unresolved_patients, remote_patients: patients[:remotes])
 
-    patients
+    {
+      locals: patients[:locals] + additional_patients[:locals],
+      remotes: additional_patients[:remotes].collect { |patient| localise_remote_patient(patient) }
+    }
   end
 
   # Locally saves the first unresolved remote patient.
@@ -360,7 +368,8 @@ class DDEService
       # HACK: Frontenders requested that if only a single patient exists
       # remotely and locally none exists, the remote patient should be
       # imported.
-      resolved_patients = [save_remote_patient(remote_patients[0])]
+      local_patient = find_patients_by_doc_id(remote_patients[0]['doc_id']).first
+      resolved_patients = [local_patient || save_remote_patient(remote_patients[0])]
       remote_patients = []
     elsif auto_push_singular_local && resolved_patients.size == 1\
          && remote_patients.empty? && local_only_patient?(resolved_patients.first)
@@ -379,12 +388,9 @@ class DDEService
 
   # Matches local and remote patient
   def same_patient?(local_patient:, remote_patient:)
-    local_npid = local_patient.identifier('National id')&.identifier
-    local_doc_id = local_patient.identifier('DDE person document id')&.identifier
-
-    return false unless local_npid && local_doc_id
-
-    local_npid == remote_patient['npid'] && local_doc_id == remote_patient['doc_id']
+    PatientIdentifier.where(patient: local_patient, type: dde_doc_id_type).any? do |doc_id|
+      doc_id.identifier == remote_patient['doc_id']
+    end
   end
 
   # Saves local patient to DDE and links the two using the IDs
@@ -533,6 +539,13 @@ class DDEService
 
   def dde_doc_id_type
     PatientIdentifierType.find_by_name('DDE Person document ID')
+  end
+
+  def find_patients_by_doc_id(doc_ids)
+    identifiers = PatientIdentifier.joins(:type)
+                                   .merge(PatientIdentifierType.where(name: 'DDE Person Document ID'))
+                                   .where(identifier: doc_ids)
+    Patient.joins(:patient_identifiers).merge(identifiers).distinct
   end
 
   def person_service

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -29,18 +29,18 @@ pacs_viewer:
 
 # Configuration for DDE
 dde:
-  url: http://localhost:5000
+  url: http://localhost:8050
 
   # This section has DDE username and password for various applications.
   # The application's name must be the same as a program name in the
   # program's table <em>but in lowercase</em>.
   hiv program:
     username: admin
-    password: bht.dde3!
+    password: bht.dde
 
   tb program:
     username: admin
-    password: bht.dde3!
+    password: bht.dde
 
 rds:
   # CouchDB configuration


### PR DESCRIPTION
In cases where a patient is available locally and in DDE (linked by DDE Person document ID) but for some reason have a different NPIDs, the patient was getting duplicated locally when the NPID in DDE was searched for.