### PR TITLE
[ART] Implemented ordering of filing number archival candidates by activation date and outcome date.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ number changes with major changes that completely break backwards
 compatibility (examples of this include major architectural changes).
 ## [Unreleased]
 
+### Added
+
+- ART: Active filing number archiving candidates preferring oldest filing numbers and patients who changed state earliest
+
 ### Fixed
 
 - Lab: Random hangs when pushing orders to LIMS (see Lab's [CHANGELOG](https://github.com/EGPAFMalawiHIS/his_emr_api_lab/blob/main/CHANGELOG.md#v1116---2021-10-18))

--- a/app/services/filing_number_service.rb
+++ b/app/services/filing_number_service.rb
@@ -137,10 +137,16 @@ class FilingNumberService
   # Build archive candidates from patient list returned by
   # `patients_to_be_archived_based_on_waste_state`
   def build_archive_candidates(patients)
-    demographics_list = find_patients_demographics_and_appointment(patients.collect { |patient| patient['patient_id'] }).to_a
+    return [] if patients.empty?
+
+    demographics_list = find_patients_demographics_and_appointment(patients.collect do |patient|
+                                                                     patient['patient_id']
+                                                                   end).to_a
 
     patients.each do |patient|
-      patient_demographics = demographics_list.bsearch { |demographics| demographics['patient_id'] >= patient['patient_id'] }
+      patient_demographics = demographics_list.bsearch do |demographics|
+        demographics['patient_id'] >= patient['patient_id']
+      end
 
       patient['appointment_date'] = patient_demographics&.fetch('appointment_date')
       patient['given_name'] = patient_demographics&.fetch('given_name')

--- a/db/migrate/20211018081109_index_patient_identifier_voided.rb
+++ b/db/migrate/20211018081109_index_patient_identifier_voided.rb
@@ -1,0 +1,6 @@
+class IndexPatientIdentifierVoided < ActiveRecord::Migration[5.2]
+  def change
+    add_index(:patient_identifier, %i[voided identifier_type identifier], name: 'index_pi_on_voided_and_identifier_type_and_identifier')
+  end
+end
+

--- a/db/migrate/20211018105619_reindex_orders_idx_orders.rb
+++ b/db/migrate/20211018105619_reindex_orders_idx_orders.rb
@@ -1,0 +1,11 @@
+class ReindexOrdersIdxOrders < ActiveRecord::Migration[5.2]
+  def change
+    if index_exists?(:orders, %i[start_date patient_id concept_id order_type_id], name: 'idx_order')
+      remove_index(:orders, name: 'idx_order')
+    end
+
+    add_index(:orders, %i[order_type_id concept_id patient_id start_date], name: 'idx_order')
+    add_index(:orders, %i[order_type_id auto_expire_date], name: 'idx_order_expiry')
+    add_index(:order_type, :name)
+  end
+end


### PR DESCRIPTION
Archiving candidates has been updated to give preference to:
- Filing numbers activated at an earlier date
- Patients who had adverse outcomes earliest

# STEPS TO TEST

This feature is exposed at GET /archiving_candidates. You need to have patients that have had an adverse outcome and have an active filing number before today (ie Transferred out, died, stopped treatment or defaulted and also were given a filing number before today). Patients with future visits are also ignored as we do not want to archive a patient that we expect to interact with at some point in the future.

Using the ART app, activate filing numbers from settings then create a new patient in BDE mode (ie any day before today). You can give the patient any adverse outcome in the same BDE mode. Hit the archiving_candidates to see if the patient is listed.

NOTE: Defaulters are given the least precedence, these are normally pulled when patients with other adverse outcomes are not available.

@andie23  I hope the stuff written above, clear up some issues you may have with archiving candidates.