### PR TITLE
Regimen Switch

### DIFF
--- a/app/services/art_service/reports/regimen_switch.rb
+++ b/app/services/art_service/reports/regimen_switch.rb
@@ -2,7 +2,6 @@
 
 module ARTService
   module Reports
-
     class RegimenSwitch
       def initialize(start_date:, end_date:)
         @start_date = start_date
@@ -10,77 +9,83 @@ module ARTService
       end
 
       def regimen_switch(pepfar)
-        return swicth_report(pepfar)
+        swicth_report(pepfar)
       end
 
       def regimen_report(type)
-        return current_regimen(type)
+        current_regimen(type)
       end
 
       private
 
       def regimen_data
         encounter_type_id = EncounterType.find_by_name('DISPENSING').id
-        arv_concept_id  = ConceptName.find_by_name('Antiretroviral drugs').concept_id
+        arv_concept_id = ConceptName.find_by_name('Antiretroviral drugs').concept_id
 
-        drug_ids = Drug.joins('INNER JOIN concept_set s ON s.concept_id = drug.concept_id').\
-          where("s.concept_set = ?", arv_concept_id).map(&:drug_id)
+        drug_ids = Drug.joins('INNER JOIN concept_set s ON s.concept_id = drug.concept_id')\
+                       .where('s.concept_set = ?', arv_concept_id).map(&:drug_id)
+
+        ActiveRecord::Base.connection.execute('drop table if exists tmp_latest_arv_dispensation ;')
+
+        ActiveRecord::Base.connection.execute("
+          create table tmp_latest_arv_dispensation
+          SELECT patient_id,DATE(MAX(start_date)) as start_date
+          FROM orders INNER JOIN drug_order t USING (order_id)
+          WHERE
+          (
+            start_date BETWEEN '#{@start_date.to_date.strftime('%Y-%m-%d 00:00:00')}' AND '#{@end_date.to_date.strftime('%Y-%m-%d 23:59:59')}'
+            AND t.drug_inventory_id IN (#{drug_ids.join(',')})
+          )
+          group by patient_id")
+
+        ActiveRecord::Base.connection.execute('create index lad_patient_id_and_start_date on tmp_latest_arv_dispensation (start_date, patient_id);')
 
         arv_dispensentions = ActiveRecord::Base.connection.select_all <<~SQL
-            SELECT
-              o.patient_id patient_id, o.start_date,  o.order_id,
-              d.quantity, drug.name
-            FROM orders o
-            INNER JOIN drug_order d ON d.order_id = o.order_id
-            INNER JOIN drug ON drug.drug_id = d.drug_inventory_id
-            WHERE d.drug_inventory_id IN(#{drug_ids.join(',')})
-            AND d.quantity > 0 AND o.voided = 0 AND DATE(o.start_date) = (
-              SELECT DATE(MAX(start_date)) FROM orders
-              INNER JOIN drug_order t USING(order_id)
-              WHERE patient_id = o.patient_id
-              AND (
-                start_date BETWEEN '#{@start_date.to_date.strftime('%Y-%m-%d 00:00:00')}'
-                AND '#{@end_date.to_date.strftime('%Y-%m-%d 23:59:59')}'
-                AND t.drug_inventory_id IN(#{drug_ids.join(',')}) AND quantity > 0
-              )
-            ) AND o.start_date BETWEEN '#{@start_date.to_date.strftime('%Y-%m-%d 00:00:00')}'
-            AND '#{@end_date.to_date.strftime('%Y-%m-%d 23:59:59')}' GROUP BY o.order_id;
+          SELECT
+            o.patient_id patient_id, o.start_date,  o.order_id,
+            d.quantity, drug.name
+          FROM orders o
+          INNER JOIN drug_order d ON o.order_id = d.order_id
+          INNER JOIN drug ON d.drug_inventory_id = drug.drug_id
+          INNER JOIN tmp_latest_arv_dispensation k on (o.patient_id = k.patient_id and DATE(o.start_date) =  k.start_date)
+          WHERE d.drug_inventory_id IN(#{drug_ids.join(',')})
+          AND d.quantity > 0 AND o.voided = 0 AND o.start_date BETWEEN '#{@start_date.to_date.strftime('%Y-%m-%d 00:00:00')}'
+          AND '#{@end_date.to_date.strftime('%Y-%m-%d 23:59:59')}' GROUP BY o.order_id;
         SQL
 
         patient_ids = []
-        (arv_dispensentions||[]).each{|data|
-          patient_ids  << data['patient_id'].to_i
-        }
+        (arv_dispensentions || []).each do |data|
+          patient_ids << data['patient_id'].to_i
+        end
         return [] if patient_ids.blank?
 
-        return ActiveRecord::Base.connection.select_all <<~SQL
-       SELECT
-        `p`.`patient_id` AS `patient_id`
-       FROM
-          ((`patient_program` `p`
-          LEFT JOIN `person` `pe` ON ((`pe`.`person_id` = `p`.`patient_id`))
-          LEFT JOIN `patient_state` `s` ON ((`p`.`patient_program_id` = `s`.`patient_program_id`)))
-          LEFT JOIN `person` ON ((`person`.`person_id` = `p`.`patient_id`)))
-       WHERE
-        ((`p`.`voided` = 0)
-        AND (`s`.`voided` = 0)
-        AND (`p`.`program_id` = 1)
-        AND (`s`.`state` = 7))
-        AND (`s`.`start_date` <= '#{@end_date.to_date.strftime('%Y-%m-%d 23:59:59')}'
-        AND p.patient_id IN(#{patient_ids.join(',')}))
-      GROUP BY `p`.`patient_id`;
-SQL
-
+        ActiveRecord::Base.connection.select_all <<~SQL
+           SELECT
+            `p`.`patient_id` AS `patient_id`
+           FROM
+              ((`patient_program` `p`
+              LEFT JOIN `person` `pe` ON ((`pe`.`person_id` = `p`.`patient_id`))
+              LEFT JOIN `patient_state` `s` ON ((`p`.`patient_program_id` = `s`.`patient_program_id`)))
+              LEFT JOIN `person` ON ((`person`.`person_id` = `p`.`patient_id`)))
+           WHERE
+            ((`p`.`voided` = 0)
+            AND (`s`.`voided` = 0)
+            AND (`p`.`program_id` = 1)
+            AND (`s`.`state` = 7))
+            AND (`s`.`start_date` <= '#{@end_date.to_date.strftime('%Y-%m-%d 23:59:59')}'
+            AND p.patient_id IN(#{patient_ids.join(',')}))
+          GROUP BY `p`.`patient_id`;
+        SQL
       end
 
       def arv_dispensention_data(patient_id)
         encounter_type_id = EncounterType.find_by_name('DISPENSING').id
-        arv_concept_id  = ConceptName.find_by_name('Antiretroviral drugs').concept_id
+        arv_concept_id = ConceptName.find_by_name('Antiretroviral drugs').concept_id
 
-        drug_ids = Drug.joins('INNER JOIN concept_set s ON s.concept_id = drug.concept_id').\
-          where("s.concept_set = ?", arv_concept_id).map(&:drug_id)
+        drug_ids = Drug.joins('INNER JOIN concept_set s ON s.concept_id = drug.concept_id')\
+                       .where('s.concept_set = ?', arv_concept_id).map(&:drug_id)
 
-         return ActiveRecord::Base.connection.select_all <<EOF
+        ActiveRecord::Base.connection.select_all <<EOF
         SELECT
           o.patient_id,  drug.name, d.quantity, o.start_date
         FROM orders o
@@ -99,42 +104,41 @@ SQL
           )
         ) GROUP BY (o.order_id);
 EOF
+      end
 
-    end
-
-    def current_regimen(type)
-      data = regimen_data
+      def current_regimen(type)
+        data = regimen_data
 
         clients = {}
         (data || []).each do |r|
           patient_id = r['patient_id'].to_i
 
-          if type == "pepfar"
-            outcome_status = ActiveRecord::Base.connection.select_one <<~SQL
-              SELECT pepfar_patient_outcome(#{patient_id}, '#{(@end_date).to_date}') outcome;
-            SQL
+          outcome_status = if type == 'pepfar'
+                             ActiveRecord::Base.connection.select_one <<~SQL
+                               SELECT pepfar_patient_outcome(#{patient_id}, '#{@end_date.to_date}') outcome;
+                             SQL
 
-          else
-            outcome_status = ActiveRecord::Base.connection.select_one <<~SQL
-              SELECT patient_outcome(#{patient_id}, '#{(@end_date).to_date}') outcome;
-            SQL
+                           else
+                             ActiveRecord::Base.connection.select_one <<~SQL
+                               SELECT patient_outcome(#{patient_id}, '#{@end_date.to_date}') outcome;
+                             SQL
 
-          end
+                           end
           next unless outcome_status['outcome'] == 'On antiretrovirals'
 
           medications = arv_dispensention_data(patient_id)
 
           begin
             visit_date = medications.first['start_date'].to_date
-          rescue
+          rescue StandardError
             next
           end
 
           curr_reg = ActiveRecord::Base.connection.select_one <<EOF
-          SELECT patient_current_regimen(#{patient_id}, '#{(@end_date).to_date}') current_regimen
+          SELECT patient_current_regimen(#{patient_id}, '#{@end_date.to_date}') current_regimen
 EOF
 
-          next unless (visit_date >= @start_date.to_date && visit_date <= @end_date.to_date)
+          next unless visit_date >= @start_date.to_date && visit_date <= @end_date.to_date
 
           if clients[patient_id].blank?
             demo = ActiveRecord::Base.connection.select_one <<EOF
@@ -161,7 +165,7 @@ EOF
             }
           end
 
-         (medications || []).each do |med|
+          (medications || []).each do |med|
             clients[patient_id][:medication] << {
               medication: med['name'],
               quantity: med['quantity'],
@@ -170,7 +174,7 @@ EOF
           end
         end
 
-        return clients
+        clients
       end
 
       def swicth_report(pepfar)
@@ -182,27 +186,27 @@ EOF
           patient_id = r['patient_id'].to_i
           medications = arv_dispensention_data(patient_id)
 
-          if pepfar
-            outcome_status = ActiveRecord::Base.connection.select_one <<EOF
-          SELECT patient_pepfar_outcome(#{patient_id}, '#{(@end_date).to_date}') outcome;
+          outcome_status = if pepfar
+                             ActiveRecord::Base.connection.select_one <<EOF
+          SELECT patient_pepfar_outcome(#{patient_id}, '#{@end_date.to_date}') outcome;
 EOF
 
-          else
-            outcome_status = ActiveRecord::Base.connection.select_one <<EOF
-          SELECT patient_outcome(#{patient_id}, '#{(@end_date).to_date}') outcome;
+                           else
+                             ActiveRecord::Base.connection.select_one <<EOF
+          SELECT patient_outcome(#{patient_id}, '#{@end_date.to_date}') outcome;
 EOF
 
-          end
+                           end
 
           next unless outcome_status['outcome'] == 'On antiretrovirals'
 
           begin
             visit_date = medications.first['start_date'].to_date
-          rescue
+          rescue StandardError
             next
           end
 
-          next unless (visit_date >= @start_date.to_date && visit_date <= @end_date.to_date)
+          next unless visit_date >= @start_date.to_date && visit_date <= @end_date.to_date
 
           prev_reg = ActiveRecord::Base.connection.select_one <<EOF
           SELECT patient_current_regimen(#{patient_id}, '#{(visit_date - 1.day).to_date}') previous_regimen
@@ -249,36 +253,36 @@ EOF
           end
         end
 
-        return clients
+        clients
       end
 
       def get_patient_type(patient_id, pepfar)
         return nil unless pepfar
+
         concept_id = ConceptName.find_by_name('Type of patient').concept_id
         ext_id = ConceptName.find_by_name('External consultation').concept_id
         obs = Observation.where(concept_id: concept_id, value_coded: ext_id, person_id: patient_id)
-        return (obs.blank? ? 'Resident' : 'External')
+        (obs.blank? ? 'Resident' : 'External')
       end
 
       def pepfar_outcome_builder
         cohort_builder = ARTService::Reports::CohortDisaggregated.new(name: 'Regimen switch', type: 'pepfar',
-        start_date: @start_date.to_date, end_date: @end_date.to_date, rebuild: true)
+                                                                      start_date: @start_date.to_date, end_date: @end_date.to_date, rebuild: true)
         cohort_builder.create_mysql_pepfar_current_defaulter
         cohort_builder.create_mysql_pepfar_current_outcome
       end
 
       def current_weight(patient_id)
-        weight_concept = ConceptName.find_by_name("Weight (kg)").concept_id
+        weight_concept = ConceptName.find_by_name('Weight (kg)').concept_id
         obs = Observation.where("person_id = ? AND concept_id = ?
           AND obs_datetime <= ? AND (value_numeric IS NOT NULL OR value_text IS NOT NULL)",
-            patient_id, weight_concept, @end_date.to_date.strftime("%Y-%m-%d 23:59:59"))\
-              .order("obs_datetime DESC, date_created DESC")
+                                patient_id, weight_concept, @end_date.to_date.strftime('%Y-%m-%d 23:59:59'))\
+                         .order('obs_datetime DESC, date_created DESC')
 
         return nil if obs.blank?
-        return (obs.first.value_numeric.blank? ? obs.first.value_text : obs.first.value_numeric)
-      end
 
+        (obs.first.value_numeric.blank? ? obs.first.value_text : obs.first.value_numeric)
+      end
     end
   end
-
 end

--- a/db/migrate/20211028142517_add_index_to_order.rb
+++ b/db/migrate/20211028142517_add_index_to_order.rb
@@ -1,0 +1,7 @@
+class AddIndexToOrder < ActiveRecord::Migration[5.2]
+  def change
+    return if ActiveRecord::Base.connection.index_exists?(:orders, %i[patient_id order_id])
+
+    add_index :orders, %i[patient_id order_id], name: 'order_id_patient_id_temp'
+  end
+end

--- a/db/migrate/20211028144234_add_index_to_drug_order.rb
+++ b/db/migrate/20211028144234_add_index_to_drug_order.rb
@@ -1,0 +1,7 @@
+class AddIndexToDrugOrder < ActiveRecord::Migration[5.2]
+  def change
+    return if ActiveRecord::Base.connection.index_exists?(:drug_order, %i[drug_inventory_id quantity])
+
+    add_index :drug_order, %i[drug_inventory_id quantity], name: 'inventory_item_and_order_quantity'
+  end
+end


### PR DESCRIPTION
Optimized the query that was fetching ARV dispensations in the regimen_data method. This query was the reason why this report was taking long. From our benchmark the method was taking more than an hour  to execute and now only a few seconds. Which has resulted in the report being generated within 15 minutes (on our machine) with this fix.

We have introduced a table `tmp_latest_arv_dispensation` that will hold patient_id and start_date info from the orders and drug_order table join. This table will be created during runtime and only serves to speed up the time in which the report is generated.

Have added two migrations that will add indexes to the following tables

1. orders
2. drug_order