### PR TITLE
Cxca/pepfar reports

### DIFF
--- a/app/services/cxca_service/report_engine.rb
+++ b/app/services/cxca_service/report_engine.rb
@@ -19,6 +19,7 @@ module CXCAService
     }.freeze
 
     def reports(start_date, end_date, name)
+      name = name.upcase
       case name
       when 'CC ALL QUESTIONS'
         REPORT_NAMES[name].new(start_date: start_date,

--- a/app/services/cxca_service/report_engine.rb
+++ b/app/services/cxca_service/report_engine.rb
@@ -14,7 +14,8 @@ module CXCAService
       'CC ALL QUESTIONS' => CXCAService::Reports::Pepfar::CcAllQuestions,
       'CC TYPE OF SCREEN' => CXCAService::Reports::Pepfar::CcAllQuestions,
       'CC SCREEN RESULT' => CXCAService::Reports::Pepfar::CcAllQuestions,
-      'CC TYPE OF TREATMENT' => CXCAService::Reports::Pepfar::CcAllQuestions
+      'CC TYPE OF TREATMENT' => CXCAService::Reports::Pepfar::CcAllQuestions,
+      'CC BASIC RESULT' => CXCAService::Reports::Pepfar::CcBasicResult
     }.freeze
 
     def reports(start_date, end_date, name)

--- a/app/services/cxca_service/report_engine.rb
+++ b/app/services/cxca_service/report_engine.rb
@@ -1,6 +1,5 @@
 module CXCAService
   class ReportEngine
-
     REPORT_NAMES = {
       'SCREENED FOR CXCA' => CXCAService::Reports::Moh::ScreenedForCxca,
       'SCREENED FOR CXCA DISAGGREGATED BY HIV STATUS' => CXCAService::Reports::Moh::ScreenedForCxcaDisaggregatedByHivStatus,
@@ -10,36 +9,55 @@ module CXCAService
       'TREATMENT OPTIONS' => CXCAService::Reports::Moh::TreatmentOptions,
       'REFERRAL REASONS' => CXCAService::Reports::Moh::ReferralReasons,
       'VISIT REASONS' => CXCAService::Reports::Clinic::VisitReasons,
-      'TREATMENT OPTIONS' => CXCAService::Reports::Moh::TreatmentOptions,
       'BOOKED CLIENTS FROM ART' => CXCAService::Reports::Clinic::BookedClientsFromArt,
-      'BOOKED CLIENTS FROM ART RAW DATA' => CXCAService::Reports::Clinic::BookedClientsFromArtRawData
+      'BOOKED CLIENTS FROM ART RAW DATA' => CXCAService::Reports::Clinic::BookedClientsFromArtRawData,
+      'CC ALL QUESTIONS' => CXCAService::Reports::Pepfar::CcAllQuestions,
+      'CC TYPE OF SCREEN' => CXCAService::Reports::Pepfar::CcAllQuestions,
+      'CC SCREEN RESULT' => CXCAService::Reports::Pepfar::CcAllQuestions,
+      'CC TYPE OF TREATMENT' => CXCAService::Reports::Pepfar::CcAllQuestions
     }.freeze
 
     def reports(start_date, end_date, name)
-      REPORT_NAMES[name].new(start_date: start_date, end_date: end_date).data
+      case name
+      when 'CC ALL QUESTIONS'
+        REPORT_NAMES[name].new(start_date: start_date,
+                               end_date: end_date).general_report
+      when 'CC TYPE OF SCREEN'
+        REPORT_NAMES[name].new(start_date: start_date,
+                               end_date: end_date).visit_report
+
+      when 'CC SCREEN RESULT'
+        REPORT_NAMES[name].new(start_date: start_date,
+                               end_date: end_date).screening_result_report
+
+      when 'CC TYPE OF TREATMENT'
+        REPORT_NAMES[name].new(start_date: start_date,
+                               end_date: end_date).treatment_resport
+      else
+        REPORT_NAMES[name].new(start_date: start_date, end_date: end_date).data
+      end
     end
 
     def dashboard_stats(date)
-      return test_performed date
+      test_performed date
     end
 
     private
 
     def test_performed(date)
-      cxca_tests = ["VIA","PAP Smear","HPV DNA","Speculum Exam"]
-      concept_names = ConceptName.where(name: cxca_tests).map{|c|[c.name, c.concept_id]}
+      cxca_tests = ['VIA', 'PAP Smear', 'HPV DNA', 'Speculum Exam']
+      concept_names = ConceptName.where(name: cxca_tests).map { |c| [c.name, c.concept_id] }
       screened_method = ConceptName.find_by_name 'CxCa screening method'
       tests = {}
 
       concept_names.each do |name, concept_id|
         tests[name] = Observation.where(value_coded: concept_id,
-          concept_id: screened_method.concept_id,
-          obs_datetime: [date.to_date.strftime('%Y-%m-%d 00:00:00')..
+                                        concept_id: screened_method.concept_id,
+                                        obs_datetime: [date.to_date.strftime('%Y-%m-%d 00:00:00')..
           date.to_date.strftime('%Y-%m-%d 23:59:59')]).count
       end
 
-      return tests
+      tests
     end
-
   end
 end

--- a/app/services/cxca_service/reports/pepfar/cc_all_questions.rb
+++ b/app/services/cxca_service/reports/pepfar/cc_all_questions.rb
@@ -62,10 +62,10 @@ module CXCAService
         def assign_to_type_of_screening(group, record)
           visit_type = Concept.find(record['value_coded']).fullname
           return  group[:first_screen] << record['patient_id'] if visit_type == 'Initial Screening'
-          return  group[:rescreen] << record['patient_id'] if ['Postponed treatment',
-                                                               'Problem visit after treatment'].include?(visit_type)
-          return  group[:follow_up_screen] << record['patient_id'] if ['One year subsequent check-up after treatment',
-                                                                       'Subsequent screening'].include?(visit_type)
+          return  group[:follow_up_screen] << record['patient_id'] if ['Postponed treatment', 'Referral',
+                                                                       'Problem visit after treatment'].include?(visit_type)
+          return  group[:rescreen] << record['patient_id'] if ['One year subsequent check-up after treatment',
+                                                               'Subsequent screening'].include?(visit_type)
         end
 
         # rubocop:disable Metrics/AbcSize

--- a/app/services/cxca_service/reports/pepfar/cc_all_questions.rb
+++ b/app/services/cxca_service/reports/pepfar/cc_all_questions.rb
@@ -5,29 +5,95 @@ module CXCAService
     module Pepfar
       # class providing all major Cervical Cancer quetions
       class CcAllQuestions
+        attr_reader :response
+
         AGE_GROUPS = ['15-19', '20-24', '25-29', '30-34', '35-39', '40-44', '45-49', '50+', 'Unknown Age'].freeze
 
         def initialize(start_date:, end_date:)
           @start_date = start_date.strftime('%Y-%m-%d 00:00:00')
           @end_date = end_date.strftime('%Y-%m-%d 23:59:59')
+          @response = init_response_structure
         end
 
-        def data; end
+        def general_report
+          visit_report(is_returning: false)
+          screening_result_report(is_returning: false)
+          treatment_resport(is_returning: false)
+          response
+        end
+
+        def visit_report(is_returning: true)
+          type_of_screening.each do |record|
+            group = response.find { |patient| patient[:age_group] == record['age_group'] }
+            assign_to_type_of_screening(group, record)
+          end
+          return response if is_returning
+        end
+
+        def screening_result_report(is_returning: true)
+          screening_result.each do |record|
+            group = response.find { |patient| patient[:age_group] == record['age_group'] }
+            assign_to_screening_result(group, record)
+          end
+          return response if is_returning
+        end
+
+        def treatment_resport(is_returning: true)
+          type_of_treatment.each do |record|
+            group = response.find { |patient| patient[:age_group] == record['age_group'] }
+            assign_to_type_of_treatment(group, record)
+          end
+          return response if is_returning
+        end
+
+        private
 
         def init_response_structure
           struct = []
           AGE_GROUPS.each do |group|
-            struct << { group => { first_Screen: [], rescreen: [], follow_Up_Screen: [],
-                                   result_negative: [], result_positive: [], result_suspected_cancer: [] } }
+            struct << { age_group: group, first_screen: [], rescreen: [], follow_up_screen: [],
+                        result_negative: [], result_positive: [],
+                        result_suspected_cancer: [], leep: [],
+                        thermocoagulation: [], cryotherapy: [] }
           end
           struct
         end
 
+        def assign_to_type_of_screening(group, record)
+          visit_type = Concept.find(record['value_coded']).fullname
+          return  group[:first_screen] << record['patient_id'] if visit_type == 'Initial Screening'
+          return  group[:rescreen] << record['patient_id'] if ['Postponed treatment',
+                                                               'Problem visit after treatment'].include?(visit_type)
+          return  group[:follow_up_screen] << record['patient_id'] if ['One year subsequent check-up after treatment',
+                                                                       'Subsequent screening'].include?(visit_type)
+        end
+
+        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/CyclomaticComplexity
+        def assign_to_screening_result(group, record)
+          result_type = Concept.find(record['value_coded']).fullname
+          if result_type.match(/negative/i) || result_type.match(/normal/i) || result_type == 'No visible Lesion'
+            return group[:result_negative] << record['patient_id']
+          end
+          if result_type.match(/positive/i) || result_type.match(/abnormal/i) || result_type == 'Visible Lesion'
+            return group[:result_positive] << record['patient_id']
+          end
+          return group[:result_suspected_cancer] << record['patient_id'] if result_type.match(/suspect/i)
+        end
+        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/CyclomaticComplexity
+
+        def assign_to_type_of_treatment(group, record)
+          treatment_type = Concept.find(record['value_coded']).fullname
+          return  group[:cryotherapy] << record['patient_id'] if treatment_type == 'Cryotherapy'
+          return  group[:thermocoagulation] << record['patient_id'] if treatment_type == 'Thermocoagulation'
+          return  group[:leep] << record['patient_id'] if treatment_type == 'LEEP'
+        end
+
         def type_of_screening
           ActiveRecord::Base.connection.select_all <<~SQL
-            SELECT e.patient_id, o.value_coded, p.birthdate FROM encounter e
+            SELECT e.patient_id, o.value_coded, cxca_age_group(p.birthdate, '#{@end_date}') as age_group FROM encounter e
             INNER JOIN obs o ON o.encounter_id = e.encounter_id AND o.voided = 0 AND o.concept_id = #{ConceptName.find_by_name('Reason for visit').concept_id}
-            AND o.value_coded IN (#{ConceptName.where(name: ['Initial Screening']).to_sql})
             INNER JOIN person p ON p.person_id = e.patient_id AND p.voided = 0
             WHERE e.voided = 0 AND e.encounter_type = #{EncounterType.find_by_name('CxCa test').id}
             AND e.encounter_datetime BETWEEN '#{@start_date}' AND '#{@end_date}'
@@ -37,8 +103,8 @@ module CXCAService
 
         def screening_result
           ActiveRecord::Base.connection.select_all <<~SQL
-            SELECT e.patient_id, o.value_coded, p.birthdate FROM encounter e
-            INNER JOIN obs o ON o.encounter_id = e.encounter_id AND o.voided = 0 AND o.concept_id = #{ConceptName.find_by_name('Screening results').concept_id}
+            SELECT e.patient_id, o.value_coded, cxca_age_group(p.birthdate, '#{@end_date}') age_group FROM encounter e
+            INNER JOIN obs o ON o.encounter_id = e.encounter_id AND o.voided = 0 AND o.concept_id = #{ConceptName.find_by_name('Screening results').concept_id} AND o.value_coded IS NOT NULL
             INNER JOIN person p ON p.person_id = e.patient_id AND p.voided = 0
             WHERE e.voided = 0 AND e.encounter_type = #{EncounterType.find_by_name('CxCa screening result').id}
             AND e.encounter_datetime BETWEEN '#{@start_date}' AND '#{@end_date}'
@@ -48,7 +114,7 @@ module CXCAService
 
         def type_of_treatment
           ActiveRecord::Base.connection.select_all <<~SQL
-            SELECT e.patient_id, o.value_coded, p.birthdate FROM encounter e
+            SELECT e.patient_id, o.value_coded, cxca_age_group(p.birthdate, '#{@end_date}') age_group FROM encounter e
             INNER JOIN obs o ON o.encounter_id = e.encounter_id AND o.voided = 0 AND o.concept_id = #{ConceptName.find_by_name('Treatment').concept_id}
             AND o.value_coded IN (#{ConceptName.where(name: %w[Cryotherapy Thermocoagulation LEEP]).select(:concept_id).to_sql})
             INNER JOIN person p ON p.person_id = e.patient_id AND p.voided = 0

--- a/app/services/cxca_service/reports/pepfar/cc_all_questions.rb
+++ b/app/services/cxca_service/reports/pepfar/cc_all_questions.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module CXCAService
+  module Reports
+    module Pepfar
+      # class providing all major Cervical Cancer quetions
+      class CcAllQuestions
+        AGE_GROUPS = ['15-19', '20-24', '25-29', '30-34', '35-39', '40-44', '45-49', '50+', 'Unknown Age'].freeze
+
+        def initialize(start_date:, end_date:)
+          @start_date = start_date.strftime('%Y-%m-%d 00:00:00')
+          @end_date = end_date.strftime('%Y-%m-%d 23:59:59')
+        end
+
+        def data; end
+
+        def init_response_structure
+          struct = []
+          AGE_GROUPS.each do |group|
+            struct << { group => { first_Screen: [], rescreen: [], follow_Up_Screen: [],
+                                   result_negative: [], result_positive: [], result_suspected_cancer: []
+                              }
+                      }
+          end
+          struct
+        end
+
+        def type_of_screening
+          ActiveRecord::Base.connection.select_all <<~SQL
+            SELECT e.patient_id, o.value_coded, p.birthdate FROM encounter e
+            INNER JOIN obs o ON o.encounter_id = e.encounter_id AND o.voided = 0 AND o.concept_id = #{ConceptName.find_by_name('Reason for visit').concept_id}
+            INNER JOIN person p ON p.person_id = e.patient_id AND p.voided = 0
+            WHERE e.voided = 0 AND e.encounter_type = #{EncounterType.find_by_name('CxCa test').id}
+            AND e.encounter_datetime BETWEEN '#{@start_date}' AND '#{@end_date}'
+            AND e.patient_id IN (#{patients_in_art_program})
+          SQL
+        end
+
+        def screening_result
+          ActiveRecord::Base.connection.select_all <<~SQL
+            SELECT e.patient_id, o.value_coded, p.birthdate FROM encounter e
+            INNER JOIN obs o ON o.encounter_id = e.encounter_id AND o.voided = 0 AND o.concept_id = #{ConceptName.find_by_name('Screening results').concept_id}
+            INNER JOIN person p ON p.person_id = e.patient_id AND p.voided = 0
+            WHERE e.voided = 0 AND e.encounter_type = #{EncounterType.find_by_name('CxCa screening result').id}
+            AND e.encounter_datetime BETWEEN '#{@start_date}' AND '#{@end_date}'
+            AND e.patient_id IN (#{patients_in_art_program})
+          SQL
+        end
+
+        def type_of_treatment
+          ActiveRecord::Base.connection.select_all <<~SQL
+          SQL
+        end
+
+        def patients_in_art_program
+          return @patients_in_art_program if @patients_in_art_program
+
+          result = ActiveRecord::Base.connection.select_all <<~SQL
+            SELECT pp.patient_id FROM patient_program pp
+            INNER JOIN person p ON pp.patient_id = p.person_id and p.voided = 0
+            WHERE p.gender = 'F' AND pp.program_id = #{Program.find_by_name('HIV Program').id} AND pp.voided = 0
+          SQL
+          @patients_in_art_program = result.map { |patient| patient['patient_id'] }.push(0).join(',')
+        end
+      end
+    end
+  end
+end

--- a/app/services/cxca_service/reports/pepfar/cc_basic_result.rb
+++ b/app/services/cxca_service/reports/pepfar/cc_basic_result.rb
@@ -29,7 +29,7 @@ module CXCAService
         def init_response_structure
           struct = []
           AGE_GROUPS.each do |group|
-            struct << { age_group: group, CXCA_SCRN_D: [], CCXCC_SCRN_N: [], CXCA_SCRN_POS: [],
+            struct << { age_group: group, CXCA_SCRN_D: [], CXCA_SCRN_N: [], CXCA_SCRN_POS: [],
                         CXCA_SCRN_TX: [] }
           end
           struct
@@ -61,8 +61,8 @@ module CXCAService
         def assign_to_screening_result_group(group, record)
           result_type = Concept.find(record['value_coded']).fullname
           if result_type.match(/negative/i) || result_type.match(/normal/i) || result_type == 'No visible Lesion'
-            group[:CCXCC_SCRN_N] << record['patient_id']
-            @total[:CCXCC_SCRN_N] << record['patient_id']
+            group[:CXCA_SCRN_N] << record['patient_id']
+            @total[:CXCA_SCRN_N] << record['patient_id']
           end
 
           if result_type.match(/positive/i) || result_type.match(/abnormal/i) || result_type == 'Visible Lesion'

--- a/app/services/cxca_service/reports/pepfar/cc_basic_result.rb
+++ b/app/services/cxca_service/reports/pepfar/cc_basic_result.rb
@@ -1,0 +1,129 @@
+# frozen_string_literals: true
+
+module CXCAService
+  module Reports
+    module Pepfar
+      # class providing all major Cervical Cancer quetions
+      class CcBasicResult
+        attr_reader :response
+
+        AGE_GROUPS = ['15-19', '20-24', '25-29', '30-34', '35-39', '40-44', '45-49', '50+', 'Unknown Age'].freeze
+
+        def initialize(start_date:, end_date:)
+          @start_date = start_date.strftime('%Y-%m-%d 00:00:00')
+          @end_date = end_date.strftime('%Y-%m-%d 23:59:59')
+          @response = init_response_structure
+        end
+
+        def data
+          process_result
+          process_screened
+          process_treatment
+          response
+        end
+
+        private
+
+        def init_response_structure
+          struct = []
+          AGE_GROUPS.each do |group|
+            struct << { age_group: group, CXCA_SCRN_D: [], CCXCC_SCRN_N: [], CXCA_SCRN_POS: [],
+                        CXCA_SCRN_TX: [] }
+          end
+          struct
+        end
+
+        def process_treatment
+          total_number_on_treatment.each do |record|
+            group = response.find { |patient| patient[:age_group] == record['age_group'] }
+            group[:CXCA_SCRN_TX] << record['patient_id']
+          end
+        end
+
+        def process_screened
+          total_number_of_clients_screened.each do |record|
+            group = response.find { |patient| patient[:age_group] == record['age_group'] }
+            group[:CXCA_SCRN_D] << record['patient_id']
+          end
+        end
+
+        def process_result
+          screening_result.each do |record|
+            group = response.find { |patient| patient[:age_group] == record['age_group'] }
+            assign_to_screening_result_group(group, record)
+          end
+        end
+
+        def assign_to_screening_result_group(group, record)
+          result_type = Concept.find(record['value_coded']).fullname
+          if result_type.match(/negative/i) || result_type.match(/normal/i) || result_type == 'No visible Lesion'
+            return group[:CCXCC_SCRN_N] << record['patient_id']
+          end
+
+          if result_type.match(/positive/i) || result_type.match(/abnormal/i) || result_type == 'Visible Lesion'
+            group[:CXCA_SCRN_POS] << record['patient_id']
+          end
+
+        end
+
+        def total_number_on_treatment
+          ActiveRecord::Base.connection.select_all <<~SQL
+            SELECT e.patient_id, o.value_coded, cxca_age_group(p.birthdate, '#{@end_date}') age_group FROM encounter e
+            INNER JOIN(
+              #{patient_filter('CxCa treatment')}
+            ) e2 ON e2.patient_id = e.patient_id AND e2.encounter_datetime = e.encounter_datetime
+            INNER JOIN obs o ON o.encounter_id = e.encounter_id AND o.voided = 0 AND o.concept_id = #{ConceptName.find_by_name('Treatment').concept_id}
+            -- AND o.value_coded IN (#{ConceptName.where(name: %w[Cryotherapy Thermocoagulation LEEP]).select(:concept_id).to_sql})
+            INNER JOIN person p ON p.person_id = e.patient_id AND p.voided = 0
+            WHERE e.voided = 0 AND e.encounter_type = #{EncounterType.find_by_name('CxCa treatment').id}
+          SQL
+        end
+
+        def screening_result
+          ActiveRecord::Base.connection.select_all <<~SQL
+            SELECT e.patient_id, o.value_coded, cxca_age_group(p.birthdate, '#{@end_date}') age_group FROM encounter e
+            INNER JOIN(
+              #{patient_filter('CxCa screening result')}
+            ) e2 ON e2.patient_id = e.patient_id AND e2.encounter_datetime = e.encounter_datetime
+            INNER JOIN obs o ON o.encounter_id = e.encounter_id AND o.voided = 0 AND o.concept_id = #{ConceptName.find_by_name('Screening results').concept_id} AND o.value_coded IS NOT NULL
+            INNER JOIN person p ON p.person_id = e.patient_id AND p.voided = 0
+            WHERE e.voided = 0 AND e.encounter_type = #{EncounterType.find_by_name('CxCa screening result').id}
+          SQL
+        end
+
+        def total_number_of_clients_screened
+          ActiveRecord::Base.connection.select_all <<~SQL
+            SELECT e.patient_id, cxca_age_group(p.birthdate, '#{@end_date}') as age_group FROM encounter e
+            INNER JOIN(
+              #{patient_filter('CxCa test')}
+            ) e2 ON e2.patient_id = e.patient_id AND e2.encounter_datetime = e.encounter_datetime
+            INNER JOIN obs o ON o.encounter_id = e.encounter_id AND o.voided = 0 AND o.concept_id = #{ConceptName.find_by_name('Reason for visit').concept_id}
+            INNER JOIN person p ON p.person_id = e.patient_id AND p.voided = 0
+            WHERE e.voided = 0 AND e.encounter_type = #{EncounterType.find_by_name('CxCa test').id}
+          SQL
+        end
+
+        def patient_filter(encounter_type)
+          <<~TEXT
+            SELECT patient_id, max(encounter_datetime) encounter_datetime FROM encounter
+            WHERE voided = 0 AND encounter_type = #{EncounterType.find_by_name(encounter_type).id}
+            AND encounter_datetime BETWEEN '#{@start_date}' AND '#{@end_date}'
+            AND patient_id IN (#{patients_in_art_program})
+            GROUP BY patient_id
+          TEXT
+        end
+
+        def patients_in_art_program
+          return @patients_in_art_program if @patients_in_art_program
+
+          result = ActiveRecord::Base.connection.select_all <<~SQL
+            SELECT pp.patient_id FROM patient_program pp
+            INNER JOIN person p ON pp.patient_id = p.person_id and p.voided = 0
+            WHERE p.gender = 'F' AND pp.program_id = #{Program.find_by_name('HIV Program').id} AND pp.voided = 0
+          SQL
+          @patients_in_art_program = result.map { |patient| patient['patient_id'] }.push(0).join(',')
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -341,6 +341,7 @@ Rails.application.routes.draw do
   get '/api/v1/:program_id/external_consultation_clients', to: 'api/v1/reports#external_consultation_clients'
 
   get '/api/v1/screened_for_cxca', to: 'api/v1/reports#cxca_reports'
+  get '/api/v1/pepfar_cxca', to: 'api/v1/reports#cxca_reports'
   get '/api/v1/dispatch_order/:order_id', to: 'api/v1/dispatch_orders#show'
   post '/api/v1/dispatch_order', to: 'api/v1/dispatch_orders#create'
   get '/api/v1/latest_regimen_dispensed', to: 'api/v1/reports#latest_regimen_dispensed'

--- a/db/sql/bart2_views_schema_additions.sql
+++ b/db/sql/bart2_views_schema_additions.sql
@@ -2076,6 +2076,30 @@ BEGIN
 	RETURN given;
 END;
 
+DROP FUNCTION IF EXISTS `cxca_age_group`;
+
+CREATE FUNCTION `cxca_age_group`(birthdate date, end_date date) RETURNS VARCHAR(15)
+BEGIN
+
+DECLARE age_in_months INT(11);
+DECLARE age_in_years INT(11);
+DECLARE age_group VARCHAR(15);
+
+SET age_in_years  = (SELECT timestampdiff(year, birthdate, end_date));
+SET age_group = ('Unknown Age');
+
+IF age_in_years >= 15 AND age_in_years <= 19 THEN SET age_group = "15-19";
+ELSEIF age_in_years >= 20 AND age_in_years <= 24 THEN SET age_group = "20-24";
+ELSEIF age_in_years >= 25 AND age_in_years <= 29 THEN SET age_group = "25-29";
+ELSEIF age_in_years >= 30 AND age_in_years <= 34 THEN SET age_group = "30-34";
+ELSEIF age_in_years >= 35 AND age_in_years <= 39 THEN SET age_group = "35-39";
+ELSEIF age_in_years >= 40 AND age_in_years <= 44 THEN SET age_group = "40-44";
+ELSEIF age_in_years >= 45 AND age_in_years <= 49 THEN SET age_group = "45-49";
+ELSEIF age_in_years >= 50 THEN SET age_group = "50+";
+END IF;
+
+RETURN age_group;
+END;
 
 
 DROP FUNCTION IF EXISTS `cohort_disaggregated_age_group`;


### PR DESCRIPTION
Added the following CXCA PEPFAR Reports:
1. CC All Questions
2. CC Type of Screen
3. CC Screen Result
4. CC Type of Treatment

This is the get endpoint 
```bash
'/api/v1/pepfar_cxca'
```

Below is the required payload
```bash
"start_date": '',
"end_date":"",
"report_name":"",
"program_id":"",
"date":""
```

The response structure is an array of hash
```bash
[
  {
     age_group: group, 
     first_screen: [], 
     rescreen: [], 
     follow_up_screen: [],
     result_negative: [], 
     result_positive: [],
     result_suspected_cancer: [], 
     leep: [],
     thermocoagulation: [], 
     cryotherapy: [] 
 }
]
```
