### PR TITLE
Feature/patient merge history

### DIFF
--- a/app/models/merge_audit.rb
+++ b/app/models/merge_audit.rb
@@ -2,4 +2,50 @@
 
 # this is the model managing all merge audits records
 class MergeAudit < VoidableRecord
+  belongs_to :winner, class_name: 'Patient', foreign_key: 'primary_id', optional: true
+  belongs_to :loser, class_name: 'Patient', foreign_key: 'secondary_id', optional: true
+
+  def as_json(options = {})
+    super(options.merge(
+      include: {
+        winner: {
+          include: {
+            person: {
+              include: {
+                names: {}
+              }
+            },
+            patient_identifiers: {
+              methods: %i[type]
+            }
+          }
+        },
+        loser: {
+          include: {
+            person: {
+              include: {
+                names: {},
+                addresses: {},
+                person_attributes: {
+                  methods: %i[type]
+                }
+              }
+            },
+            patient_identifiers: {
+              methods: %i[type]
+            }
+          }
+        }
+      },
+      methods: %i[looser]
+    ))
+  end
+
+  def looser
+    patient = Patient.unscoped.find(secondary_id).as_json
+    patient['person'] = Person.unscoped.find(secondary_id).as_json
+    patient['person']['names'] = PersonName.unscoped.where(person_id: secondary_id).as_json
+    patient['patient_identifiers'] = PatientIdentifier.unscoped.where(patient_id: secondary_id).as_json
+    patient
+  end
 end

--- a/app/models/merge_audit.rb
+++ b/app/models/merge_audit.rb
@@ -45,7 +45,7 @@ class MergeAudit < VoidableRecord
     patient = Patient.unscoped.find(secondary_id).as_json
     patient['person'] = Person.unscoped.find(secondary_id).as_json
     patient['person']['names'] = PersonName.unscoped.where(person_id: secondary_id).as_json
-    patient['patient_identifiers'] = PatientIdentifier.unscoped.where(patient_id: secondary_id).as_json
+    patient['patient_identifiers'] = PatientIdentifier.unscoped.where(patient_id: secondary_id).as_json(includes: :type)
     patient
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -41,7 +41,8 @@ class Patient < VoidableRecord
         patient_identifiers: {
           methods: %i[type]
         }
-      }
+      },
+      methods: %i[merge_history]
     ))
   end
 
@@ -130,6 +131,6 @@ class Patient < VoidableRecord
   end
 
   def merge_history
-    MergeAudit.where(primary_id: patient_id)
+    MergeAudit.where(primary_id: patient_id).order(:created_at)
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -131,6 +131,6 @@ class Patient < VoidableRecord
   end
 
   def merge_history
-    MergeAudit.where(primary_id: patient_id).order(:created_at)
+    MergeAudit.where(primary_id: patient_id).order(:created_at).as_json
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -107,10 +107,10 @@ class Patient < VoidableRecord
 
   def void_related_models(reason)
     person.void(reason)
-    patient_identifiers.each { |row| row.void(reason) }
-    patient_programs.each { |row| row.void(reason) }
-    orders.each { |row| row.void(reason) }
-    encounters.each { |row| row.void(reason) }
+    patient_identifiers.each { |row| row.void(reason) if row['voided'].zero? }
+    patient_programs.each { |row| row.void(reason) if row['voided'].zero? }
+    orders.each { |row| row.void(reason) if row['voided'].zero? }
+    encounters.each { |row| row.void(reason) if row['voided'].zero? }
   end
 
   def gender

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -128,4 +128,8 @@ class Patient < VoidableRecord
   def name
     PersonName.where(person_id: patient_id).order(:date_created).last&.to_s
   end
+
+  def merge_history
+    MergeAudit.where(primary_id: patient_id)
+  end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -50,10 +50,10 @@ class Person < VoidableRecord
   end
 
   def void_related_models(reason)
-    names.each { |name| name.void(reason) }
-    addresses.each { |address| address.void(reason) }
-    relationships.each { |relationship| relationship.void(reason) }
-    person_attributes.each { |attribute| attribute.void(reason) }
+    names.each { |name| name.void(reason) if name['voided'].zero? }
+    addresses.each { |address| address.void(reason) if address['voided'].zero? }
+    relationships.each { |relationship| relationship.void(reason) if relationship['voided'].zero? }
+    person_attributes.each { |attribute| attribute.void(reason) if attribute['voided'].zero? }
     # We are going to rely on patient => encounter => obs to void those
   end
 end

--- a/app/services/dde_merging_service.rb
+++ b/app/services/dde_merging_service.rb
@@ -34,7 +34,7 @@ class DDEMergingService
       elsif remote_local_merge?(primary_patient_ids, secondary_patient_ids)
         merge_remote_and_local_patients(primary_patient_ids, secondary_patient_ids, 'Remote and Local Patient')
       elsif inverted_remote_local_merge?(primary_patient_ids, secondary_patient_ids)
-        merge_remote_and_local_patients(secondary_patient_ids, primary_patient_ids, 'Local and Remote Patients')
+        merge_local_patients(primary_patient_ids, secondary_patient_ids, 'Local and Remote Patients')
       elsif local_merge?(primary_patient_ids, secondary_patient_ids)
         merge_local_patients(primary_patient_ids, secondary_patient_ids, 'Local Patients')
       else
@@ -148,6 +148,11 @@ class DDEMergingService
     local_patient = link_local_to_remote_patient(local_patient, remote_patient)
     return local_patient if secondary_patient_ids['patient_id'].blank?
 
+    merge_local_patients(primary_patient_ids, secondary_patient_ids, merge_type)
+  end
+
+  # Merge remote secondary patient into local primary patient
+  def merge_local_and_remote_patients(primary_patient_ids, secondary_patient_ids, merge_type)
     merge_local_patients(primary_patient_ids, secondary_patient_ids, merge_type)
   end
 

--- a/app/services/dde_merging_service.rb
+++ b/app/services/dde_merging_service.rb
@@ -115,22 +115,29 @@ class DDEMergingService
   # The precondition for a remote merge is the presence of a doc_id
   # in both primary and secondary patient ids.
   def remote_merge?(primary_patient_ids, secondary_patient_ids)
-    !primary_patient_ids['doc_id'].blank? && !secondary_patient_ids['doc_id'].blank?
+    !search_by_doc_id(primary_patient_ids['doc_id']).blank? && !search_by_doc_id(secondary_patient_ids['doc_id']).blank?
   end
 
   # Is a merge of a remote patient into a local patient possible?
   def remote_local_merge?(primary_patient_ids, secondary_patient_ids)
-    !primary_patient_ids['patient_id'].blank? && !secondary_patient_ids['doc_id'].blank?
+    !primary_patient_ids['patient_id'].blank? && !search_by_doc_id(secondary_patient_ids['doc_id']).blank?
   end
 
   # Like `remote_local_merge` but primary is remote and secondary is local
   def inverted_remote_local_merge?(primary_patient_ids, secondary_patient_ids)
-    !primary_patient_ids['doc_id'].blank? && !secondary_patient_ids['patient_id'].blank?
+    !search_by_doc_id(primary_patient_ids['doc_id']).blank? && !secondary_patient_ids['patient_id'].blank?
   end
 
   # Is a merge of local patients possible?
   def local_merge?(primary_patient_ids, secondary_patient_ids)
     !primary_patient_ids['patient_id'].blank? && !secondary_patient_ids['patient_id'].blank?
+  end
+
+  def search_by_doc_id(doc_id)
+    response, status = dde_client.post('search_by_doc_id', doc_id: doc_id)
+    return nil unless status == 200
+
+    response
   end
 
   # Merge remote secondary patient into local primary patient

--- a/app/services/patient_service.rb
+++ b/app/services/patient_service.rb
@@ -14,7 +14,7 @@ class PatientService
       if use_dde_service?
         begin
           assign_patient_dde_npid(patient, program)
-        rescue RuntimeError => e
+        rescue
           create_local_npid(patient, malawi_national_id)
         end
       else

--- a/lib/dde_client.rb
+++ b/lib/dde_client.rb
@@ -131,6 +131,9 @@ class DDEClient
   rescue RestClient::UnprocessableEntity => e
     LOGGER.error "DDEClient suppressed exception: #{e}"
     handle_response e.response
+  rescue RestClient::NotFound => e
+    LOGGER.error "DDEClient suppressed exception: #{e}"
+    handle_response e.response
   end
 
   def handle_response(response)


### PR DESCRIPTION
This is to provide a way of finding out if there has been any merge history on the identifier being searched. The front-end has to check if there is merge_history data.

The payload now looks like this
```bash
[
  {
    patient_id: 0,
    merge_history: [
      {
          primary_id: number,
          secondary_id: number,
          winner: patient_object,
          looser: patient_object
      }
    ],
    person: object,
    patient_identifiers: array
  }
]
```
