### PR TITLE
Fix Incomplete visits

### DIFF
--- a/app/services/art_service/reports/visits_report.rb
+++ b/app/services/art_service/reports/visits_report.rb
@@ -49,7 +49,7 @@ class ARTService::Reports::VisitsReport
       SELECT patient.* FROM patient INNER JOIN encounter USING (patient_id)
        WHERE encounter.encounter_datetime BETWEEN ? AND ?
         AND encounter.encounter_type NOT IN (
-          SELECT encounter_type_id FROM encounter_type WHERE name IN ('LAB', 'LAB ORDER', 'LAB RESULTS')
+          SELECT encounter_type_id FROM encounter_type WHERE name IN ('LAB', 'LAB ORDER', 'LAB ORDERS', 'LAB RESULTS')
         )
         AND encounter.program_id = #{hiv_program.program_id}
         AND encounter.voided = 0

--- a/app/services/patient_service.rb
+++ b/app/services/patient_service.rb
@@ -116,6 +116,7 @@ class PatientService
       WHERE patient_id = #{patient_id} AND voided = 0 #{if program_id
                                                           "AND program_id = #{program_id}"
                                                         end} AND encounter_datetime < DATE('#{date}') + INTERVAL 1 DAY
+      AND encounter_type NOT IN (#{EncounterType.where(name: ['LAB', 'LAB ORDERS', 'LAB RESULTS']).select(:encounter_type_id).to_sql})
       GROUP BY visit_date
       ORDER BY visit_date DESC
     SQL


### PR DESCRIPTION
A fix on helpdesk issue number 6250. This fixes false incomplete visits because of lab orders encounter created when entering lab results. 