### PR TITLE
TPT outcome report

### DIFF
--- a/app/services/art_service/reports/pepfar/tb_prev3.rb
+++ b/app/services/art_service/reports/pepfar/tb_prev3.rb
@@ -253,7 +253,7 @@ module ARTService
           return { start_date: '1900-01-01', end_date: end_date } if result.blank?
 
           sorted_result = result.sort { |a, b| a['end_date'].to_date <=> b['start_date'].to_date }.reverse
-          return_date = { start_date: '1900-01-01', end_date: end_date }
+          return_date = { start_date: sorted_result.last['start_date'], end_date: end_date }
 
           course_interruption = result.first['course'] == '3HP' ? 1 : 2
           # loop through the result array and find the first gap in the dates that equals the course interruption

--- a/app/services/art_service/reports/pepfar/tb_prev3.rb
+++ b/app/services/art_service/reports/pepfar/tb_prev3.rb
@@ -48,6 +48,10 @@ module ARTService
                  end, completed: completed }
         end
 
+        def fetch_individual_report(patient_id)
+          individual_tpt_report(patient_id)
+        end
+
         private
 
         def init_report

--- a/app/services/art_service/reports/tpt_outcome.rb
+++ b/app/services/art_service/reports/tpt_outcome.rb
@@ -80,7 +80,21 @@ module ARTService
       def tpt_clients
         ActiveRecord::Base.connection.select_all <<~SQL
           SELECT
-            e.patient_id
+            pp.patient_id,
+            DATE(min(o.start_date)) AS start_date,
+            DATE(max(o.start_date)) AS last_dispense_date,
+            patient_outcome(p.person_id, DATE('#{@end_date}')) AS outcome,
+            SUM(dor.quantity) AS total_pills_taken,
+            SUM(DATEDIFF(o.auto_expire_date, o.start_date)) AS total_days_on_medication,
+            p.gender,
+            p.birthdate,
+            disaggregated_age_group(p.birthdate, DATE('#{@end_date}')) AS age_group,
+            GROUP_CONCAT(DISTINCT o.concept_id SEPARATOR ',') AS drug_concepts,
+            CASE
+              WHEN count(DISTINCT o.concept_id) >  1 THEN '3HP'
+              WHEN o.concept_id = 10565 THEN '3HP'
+              ELSE '6H'
+            END AS tpt_type
           FROM patient_program pp
           INNER JOIN patient_state ps ON ps.patient_program_id = pp.patient_program_id AND ps.voided = 0 AND ps.state = 7
           INNER JOIN person p ON p.person_id = pp.patient_id AND p.voided = 0
@@ -109,24 +123,6 @@ module ARTService
             GROUP BY e.patient_id
           ) clients_on_tpt ON clients_on_tpt.patient_id = e.patient_id
           WHERE pp.program_id = 1 /* HIV Program */
-            AND pp.patient_id NOT IN (
-              /* Exclude patients who had TPT dispensation before */
-              SELECT
-                e.patient_id
-              FROM patient_program pp
-              INNER JOIN patient_state ps ON ps.patient_program_id = pp.patient_program_id AND ps.voided = 0 AND ps.state = 7
-              INNER JOIN person p ON p.person_id = pp.patient_id AND p.voided = 0
-              INNER JOIN encounter e ON e.patient_id = pp.patient_id
-                AND e.encounter_type = 25 /* Treatment */
-                AND e.voided = 0
-                AND e.program_id = 1 /* HIV Program */
-              INNER JOIN orders o ON o.encounter_id = e.encounter_id
-                AND o.order_type_id = #{OrderType.find_by_name('Drug order').id}
-                AND o.voided = 0
-                AND o.concept_id IN (#{tpt_drugs.to_sql})
-                AND DATE(o.start_date) BETWEEN #{first_day_of_month} - INTERVAL 1 MONTH AND DATE(#{first_day_of_month}) - INTERVAL 1 DAY
-              INNER JOIN drug_order dor ON dor.order_id = o.order_id AND dor.voided = 0 AND dor.quantity > 0
-            )
             AND pp.patient_id  NOT IN (
               /* External consultations */
               SELECT DISTINCT registration_encounter.patient_id
@@ -159,7 +155,8 @@ module ARTService
               WHERE patient_program.voided = 0
             )
             AND pp.voided = 0
-            AND ps.start_date >= DATE('#{@start_date}') AND ps.start_date <= DATE('#{@end_date}')
+            AND DATE(o.start_date)<= DATE('#{@end_date}')
+            GROUP BY pp.patient_id
         SQL
       end
 

--- a/app/services/art_service/reports/tpt_outcome.rb
+++ b/app/services/art_service/reports/tpt_outcome.rb
@@ -14,11 +14,12 @@ module ARTService
       def initialize(start_date:, end_date:, **_kwarg)
         @start_date = start_date.to_date
         @end_date = end_date.to_date
+        @tb_prev = ARTService::Reports::Pepfar::TbPrev3.new(start_date: @start_date, end_date: @end_date)
       end
 
       def find_report
         report = init_report
-        load_patients_into_report report, tpt_clients
+        load_patients_into_report report, process_tpt_clients
         response = []
         report.each do |key, value|
           response << { age_group: key, tpt_type: '3HP', **value['3HP'] }
@@ -81,11 +82,7 @@ module ARTService
         ActiveRecord::Base.connection.select_all <<~SQL
           SELECT
             pp.patient_id,
-            DATE(min(o.start_date)) AS start_date,
-            DATE(max(o.start_date)) AS last_dispense_date,
             patient_outcome(p.person_id, DATE('#{@end_date}')) AS outcome,
-            SUM(dor.quantity) AS total_pills_taken,
-            SUM(DATEDIFF(o.auto_expire_date, o.start_date)) AS total_days_on_medication,
             p.gender,
             p.birthdate,
             disaggregated_age_group(p.birthdate, DATE('#{@end_date}')) AS age_group,
@@ -106,7 +103,7 @@ module ARTService
             AND o.order_type_id = #{OrderType.find_by_name('Drug order').id}
             AND o.voided = 0
             AND o.concept_id IN (#{tpt_drugs.to_sql})
-          INNER JOIN drug_order dor ON dor.order_id = o.order_id AND dor.voided = 0 AND dor.quantity > 0
+          INNER JOIN drug_order dor ON dor.order_id = o.order_id AND dor.quantity > 0
           INNER JOIN (
             SELECT e.patient_id
             FROM encounter e
@@ -115,7 +112,7 @@ module ARTService
               AND o.order_type_id = #{OrderType.find_by_name('Drug order').id}
               AND o.concept_id IN (#{tpt_drugs.to_sql})
               AND DATE(o.start_date) BETWEEN #{first_day_of_month} AND DATE(#{last_day_of_month})
-            INNER JOIN drug_order dor ON dor.order_id = o.order_id AND dor.voided = 0 AND dor.quantity > 0
+            INNER JOIN drug_order dor ON dor.order_id = o.order_id AND dor.quantity > 0
             WHERE e.encounter_type = 25 /* Treatment */
               AND e.voided = 0
               AND e.program_id = 1 /* HIV Program */
@@ -160,93 +157,110 @@ module ARTService
         SQL
       end
 
-      def tpt_clients
-        ActiveRecord::Base.connection.select_all <<~SQL
-          SELECT
-            p.person_id AS patient_id,
-            DATE(min(o.start_date)) AS start_date,
-            DATE(max(o.start_date)) AS last_dispense_date,
-            patient_outcome(p.person_id, DATE('#{@end_date}')) AS outcome,
-            SUM(d.quantity) AS total_pills_taken,
-            SUM(DATEDIFF(o.auto_expire_date, o.start_date)) AS total_days_on_medication,
-            p.gender,
-            p.birthdate,
-            disaggregated_age_group(p.birthdate, DATE('#{@end_date}')) AS age_group,
-            GROUP_CONCAT(DISTINCT o.concept_id SEPARATOR ',') AS drug_concepts,
-            CASE
-              WHEN count(DISTINCT o.concept_id) >  1 THEN '3HP'
-              WHEN o.concept_id = 10565 THEN '3HP'
-              ELSE '6H'
-            END AS tpt_type
-          FROM person p
-          INNER JOIN encounter e
-            ON e.patient_id = p.person_id
-            AND e.encounter_type = #{EncounterType.find_by_name('Treatment').id}
-            AND e.voided = 0
-            AND e.program_id = #{Program.find_by_name('HIV PROGRAM').id}
-            AND e.encounter_datetime >= DATE('#{@start_date}') - INTERVAL 6 MONTH
-            AND e.encounter_datetime <= DATE('#{@start_date}')
-          INNER JOIN orders o
-            ON o.encounter_id = e.encounter_id
-            AND o.concept_id IN (#{tpt_drugs.to_sql})
-            AND o.start_date >= DATE('#{@start_date}') - INTERVAL 6 MONTH
-            AND o.start_date <= DATE('#{@end_date}')
-            AND o.voided = 0
-            AND o.order_type_id = #{OrderType.find_by_name('Drug order').id}
-          INNER JOIN drug_order d ON d.order_id = o.order_id AND d.quantity > 0
-          WHERE p.voided = 0
-          AND p.person_id NOT IN (
-            SELECT p.person_id
-            FROM person p
-            INNER JOIN encounter e
-              ON e.patient_id = p.person_id
-              AND e.encounter_type = #{EncounterType.find_by_name('Treatment').id}
-              AND e.voided = 0
-              AND e.program_id = #{Program.find_by_name('HIV PROGRAM').id}
-            INNER JOIN orders o
-              ON o.patient_id = e.patient_id
-              AND o.concept_id IN (#{tpt_drugs.to_sql})
-              AND o.voided = 0
-              AND o.order_type_id = #{OrderType.find_by_name('Drug order').id}
-            INNER JOIN drug_order d ON d.order_id = o.order_id AND d.quantity > 0
-            WHERE p.voided = 0
-              AND e.encounter_datetime < '#{@start_date - 6.months}'
-              AND e.encounter_datetime >= '#{@start_date - 15.months}'
-          )
-          AND p.person_id NOT IN (
-            /* External consultations */
-            SELECT DISTINCT registration_encounter.patient_id
-            FROM patient_program
-            INNER JOIN program ON program.name = 'HIV Program'
-            INNER JOIN encounter AS registration_encounter
-              ON registration_encounter.patient_id = patient_program.patient_id
-              AND registration_encounter.program_id = patient_program.program_id
-              AND registration_encounter.encounter_datetime < DATE(#{@end_date}) + INTERVAL 1 DAY
-              AND registration_encounter.voided = 0
-            INNER JOIN (
-              SELECT MAX(encounter.encounter_datetime) AS encounter_datetime, encounter.patient_id
-              FROM encounter
-              INNER JOIN encounter_type
-                ON encounter_type.encounter_type_id = encounter.encounter_type
-                AND encounter_type.name = 'Registration'
-              INNER JOIN program
-                ON program.program_id = encounter.program_id
-                AND program.name = 'HIV Program'
-              WHERE encounter.encounter_datetime < DATE(#{@end_date}) AND encounter.voided = 0
-              GROUP BY encounter.patient_id
-            ) AS max_registration_encounter
-              ON max_registration_encounter.patient_id = registration_encounter.patient_id
-              AND max_registration_encounter.encounter_datetime = registration_encounter.encounter_datetime
-            INNER JOIN obs AS patient_type_obs
-              ON patient_type_obs.encounter_id = registration_encounter.encounter_id
-              AND patient_type_obs.concept_id IN (SELECT concept_id FROM concept_name WHERE name = 'Type of patient' AND voided = 0)
-              AND patient_type_obs.value_coded IN (SELECT concept_id FROM concept_name WHERE name IN ('Drug refill', 'External consultation') AND voided = 0)
-              AND patient_type_obs.voided = 0
-            WHERE patient_program.voided = 0
-          )
-          GROUP BY p.person_id
-        SQL
+      def process_tpt_clients
+        clients = []
+        tpt_clients.each do |client|
+          result = @tb_prev.fetch_individual_report(client['patient_id'])
+          next if result.blank?
+          next if result['tpt_initiation_date'].to_date < first_day_of_month.to_date
+
+          client['start_date'] = result['tpt_initiation_date']
+          client['last_dispense_date'] = result['last_dispensed_date']
+          client['total_pills_taken'] = result['total_pills_taken']
+          client['total_days_on_medication'] = result['total_days_on_medication']
+
+          clients << client
+        end
+        clients
       end
+
+      # def tpt_clients
+      #   ActiveRecord::Base.connection.select_all <<~SQL
+      #     SELECT
+      #       p.person_id AS patient_id,
+      #       DATE(min(o.start_date)) AS start_date,
+      #       DATE(max(o.start_date)) AS last_dispense_date,
+      #       patient_outcome(p.person_id, DATE('#{@end_date}')) AS outcome,
+      #       SUM(d.quantity) AS total_pills_taken,
+      #       SUM(DATEDIFF(o.auto_expire_date, o.start_date)) AS total_days_on_medication,
+      #       p.gender,
+      #       p.birthdate,
+      #       disaggregated_age_group(p.birthdate, DATE('#{@end_date}')) AS age_group,
+      #       GROUP_CONCAT(DISTINCT o.concept_id SEPARATOR ',') AS drug_concepts,
+      #       CASE
+      #         WHEN count(DISTINCT o.concept_id) >  1 THEN '3HP'
+      #         WHEN o.concept_id = 10565 THEN '3HP'
+      #         ELSE '6H'
+      #       END AS tpt_type
+      #     FROM person p
+      #     INNER JOIN encounter e
+      #       ON e.patient_id = p.person_id
+      #       AND e.encounter_type = #{EncounterType.find_by_name('Treatment').id}
+      #       AND e.voided = 0
+      #       AND e.program_id = #{Program.find_by_name('HIV PROGRAM').id}
+      #       AND e.encounter_datetime >= DATE('#{@start_date}') - INTERVAL 6 MONTH
+      #       AND e.encounter_datetime <= DATE('#{@start_date}')
+      #     INNER JOIN orders o
+      #       ON o.encounter_id = e.encounter_id
+      #       AND o.concept_id IN (#{tpt_drugs.to_sql})
+      #       AND o.start_date >= DATE('#{@start_date}') - INTERVAL 6 MONTH
+      #       AND o.start_date <= DATE('#{@end_date}')
+      #       AND o.voided = 0
+      #       AND o.order_type_id = #{OrderType.find_by_name('Drug order').id}
+      #     INNER JOIN drug_order d ON d.order_id = o.order_id AND d.quantity > 0
+      #     WHERE p.voided = 0
+      #     AND p.person_id NOT IN (
+      #       SELECT p.person_id
+      #       FROM person p
+      #       INNER JOIN encounter e
+      #         ON e.patient_id = p.person_id
+      #         AND e.encounter_type = #{EncounterType.find_by_name('Treatment').id}
+      #         AND e.voided = 0
+      #         AND e.program_id = #{Program.find_by_name('HIV PROGRAM').id}
+      #       INNER JOIN orders o
+      #         ON o.patient_id = e.patient_id
+      #         AND o.concept_id IN (#{tpt_drugs.to_sql})
+      #         AND o.voided = 0
+      #         AND o.order_type_id = #{OrderType.find_by_name('Drug order').id}
+      #       INNER JOIN drug_order d ON d.order_id = o.order_id AND d.quantity > 0
+      #       WHERE p.voided = 0
+      #         AND e.encounter_datetime < '#{@start_date - 6.months}'
+      #         AND e.encounter_datetime >= '#{@start_date - 15.months}'
+      #     )
+      #     AND p.person_id NOT IN (
+      #       /* External consultations */
+      #       SELECT DISTINCT registration_encounter.patient_id
+      #       FROM patient_program
+      #       INNER JOIN program ON program.name = 'HIV Program'
+      #       INNER JOIN encounter AS registration_encounter
+      #         ON registration_encounter.patient_id = patient_program.patient_id
+      #         AND registration_encounter.program_id = patient_program.program_id
+      #         AND registration_encounter.encounter_datetime < DATE(#{@end_date}) + INTERVAL 1 DAY
+      #         AND registration_encounter.voided = 0
+      #       INNER JOIN (
+      #         SELECT MAX(encounter.encounter_datetime) AS encounter_datetime, encounter.patient_id
+      #         FROM encounter
+      #         INNER JOIN encounter_type
+      #           ON encounter_type.encounter_type_id = encounter.encounter_type
+      #           AND encounter_type.name = 'Registration'
+      #         INNER JOIN program
+      #           ON program.program_id = encounter.program_id
+      #           AND program.name = 'HIV Program'
+      #         WHERE encounter.encounter_datetime < DATE(#{@end_date}) AND encounter.voided = 0
+      #         GROUP BY encounter.patient_id
+      #       ) AS max_registration_encounter
+      #         ON max_registration_encounter.patient_id = registration_encounter.patient_id
+      #         AND max_registration_encounter.encounter_datetime = registration_encounter.encounter_datetime
+      #       INNER JOIN obs AS patient_type_obs
+      #         ON patient_type_obs.encounter_id = registration_encounter.encounter_id
+      #         AND patient_type_obs.concept_id IN (SELECT concept_id FROM concept_name WHERE name = 'Type of patient' AND voided = 0)
+      #         AND patient_type_obs.value_coded IN (SELECT concept_id FROM concept_name WHERE name IN ('Drug refill', 'External consultation') AND voided = 0)
+      #         AND patient_type_obs.voided = 0
+      #       WHERE patient_program.voided = 0
+      #     )
+      #     GROUP BY p.person_id
+      #   SQL
+      # end
 
       def load_patients_into_report(report, patients)
         patients.each do |patient|

--- a/app/services/art_service/reports/tpt_outcome.rb
+++ b/app/services/art_service/reports/tpt_outcome.rb
@@ -80,6 +80,29 @@ module ARTService
       def tpt_clients
         ActiveRecord::Base.connection.select_all <<~SQL
           SELECT
+            e.patient_id
+          FROM patient_program pp
+          INNER JOIN patient_state ps ON ps.patient_program_id = pp.patient_program_id AND ps.voided = 0 AND ps.state = 7
+          INNER JOIN person p ON p.person_id = pp.patient_id AND p.voided = 0
+          INNER JOIN encounter e ON e.patient_id = pp.patient_id
+            AND e.encounter_type = 25 /* Treatment */
+            AND e.voided = 0
+            AND e.program_id = 1 /* HIV Program */
+          INNER JOIN orders o ON o.encounter_id = e.encounter_id
+            AND o.order_type_id = #{OrderType.find_by_name('Drug order').id}
+            AND o.voided = 0
+            AND o.concept_id IN (#{tpt_drugs.to_sql})
+            AND DATE(o.start_date) BETWEEN #{first_day_of_month} AND DATE(#{last_day_of_month})
+          INNER JOIN drug_order dor ON dor.order_id = o.order_id AND dor.voided = 0 AND dor.quantity > 0
+          WHERE pp.program_id = 1 /* HIV Program */
+          AND pp.voided = 0
+          AND ps.start_date >= DATE('#{@start_date}') AND ps.start_date <= DATE('#{@end_date}')
+        SQL
+      end
+
+      def tpt_clients
+        ActiveRecord::Base.connection.select_all <<~SQL
+          SELECT
             p.person_id AS patient_id,
             DATE(min(o.start_date)) AS start_date,
             DATE(max(o.start_date)) AS last_dispense_date,
@@ -202,6 +225,14 @@ module ARTService
 
       def tpt_drugs
         ConceptName.where(name: ['INH', 'Isoniazid/Rifapentine', 'Rifapentine']).select(:concept_id)
+      end
+
+      def first_day_of_month
+        @first_day_of_month ||= ActiveRecord::Base.connection.quote((@start_date - 6.month).beginning_of_month)
+      end
+
+      def last_day_of_month
+        @last_day_of_month ||= ActiveRecord::Base.connection.quote((@start_date - 6.month).end_of_month)
       end
     end
   end


### PR DESCRIPTION
Logic on how the TPT Outcome Report has changed. Below is the new logic

When a user inputs a start date, the system goes back six months and pick clients from that month who started TPT. The system gets these clients and check the current outcome at the end of the user input end date.