### PR TITLE
fixes on the VL Coverage report

### DIFF
--- a/app/services/art_service/reports/pepfar/viral_load_coverage2.rb
+++ b/app/services/art_service/reports/pepfar/viral_load_coverage2.rb
@@ -84,6 +84,7 @@ module ARTService
           length = 6 if patient['maternal_status'] == 'FBf'
           length = 6 if patient['current_regimen'].to_s.match(/P/i)
 
+          return false if patient['vl_order_date'] && patient['vl_order_date'].to_date >= end_date - 12.months && patient['vl_order_date'].to_date <= end_date
           return false if last_date.to_date + length.months < patient['outcome_date'].to_date
 
           true


### PR DESCRIPTION
This fixes a bug that was removing clients who had an adverse outcome after VL Test done within the same reporting period.

Issue can be found under this ticket https://trello.com/c/CCeLUp1I/156-vl-coverage

# *Remember if this passes to rebase*