### PR TITLE
Regimen Distribution by Weight & Gender

### DIFF
--- a/app/services/art_service/reports/regimens_by_weight_and_gender.rb
+++ b/app/services/art_service/reports/regimens_by_weight_and_gender.rb
@@ -99,7 +99,7 @@ module ARTService
         Observation.joins('INNER JOIN temp_patient_outcomes AS outcomes ON outcomes.patient_id = obs.person_id')
                    .where(concept_id: ConceptName.where(name: 'Weight (kg)').select(:concept_id),
                           outcomes: { cum_outcome: 'On antiretrovirals' })
-                   .where('obs.obs_datetime < ?', end_date)
+                   .where('DATE(obs.obs_datetime) <= ?', end_date)
                    .group(:person_id)
       end
     end


### PR DESCRIPTION
fixes a bug where clients where not showing under their weight band, specifically for those captured on the end date of the report.

This is the ticket https://trello.com/c/zqHghBby/153-regimen-by-weight

# *Remember if this passes to rebase*