### PR TITLE
added next appointment endpoint

### DIFF
--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -30,6 +30,17 @@ class Api::V1::AppointmentsController < ApplicationController
     end
   end
 
+  def next_appointment
+    accepted_params = params.permit(%i[patient_id date program_id])
+    encounter = Encounter.where('encounter_type = ? AND patient_id = ? AND DATE(encounter_datetime) <= ? AND program_id = ?', EncounterType.find_by_name('APPOINTMENT').id, accepted_params[:patient_id], accepted_params[:date], accepted_params[:program_id])&.last
+    obs = encounter ? encounter.observations&.where('concept_id = ?', ConceptName.find_by_name('APPOINTMENT DATE').concept_id)&.last : nil
+    if obs
+      render json: { appointment_date: obs.value_datetime.strftime('%Y-%m-%d')}
+    else
+      render json: { errors: 'No appointment found' }, status: :not_found
+    end
+  end
+
   def update
     # TODO: Implement me
     render json: { errors: ['Not implemented'] }, status: :not_found

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -380,4 +380,6 @@ Rails.application.routes.draw do
 
   post '/api/v1/pharmacy/items/batch_update', to: 'api/v1/pharmacy/items#batch_update'
 
+  get '/api/v1/next_appointment', to: 'api/v1/appointments#next_appointment'
+
 end

--- a/spec/requests/api/v1/appointments_spec.rb
+++ b/spec/requests/api/v1/appointments_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+TAG_NAME = 'Appointments'
+TAG_DESCRIPTION = 'Appointments Endpoints'
+
+RSpec.describe 'api/v1/appointments', type: :request do
+
+  path '/api/v1/next_appointment' do
+
+    get('list appointments') do
+      tags TAG_NAME
+      description TAG_DESCRIPTION
+      consumes 'application/json'
+      produces 'application/json'
+      security [api_key: []]
+      parameter name: :patient_id, in: :query, type: :integer, example: 1, description: 'Patient ID', required: true, default: 1
+      parameter name: :program_id, in: :query, type: :integer, example: 1, description: 'Program ID', required: true, default: 1
+      parameter name: :date, in: :query, type: :string, format: 'date', example: '2020-01-01', description: 'Date in YYYY-MM-DD format', required: true
+
+      response(200, 'successful') do
+        schema type: :object, properties: {
+          appointment_date: { type: :string, format: 'date' },
+        }, required: %w[appointment_date]
+
+        run_test!
+      end
+
+      response(404, 'not found') do
+        let(:patient_id) { 'invalid' }
+        let(:program_id) { 'invalid' }
+        let(:date) { 'invalid' }
+
+        schema type: :object, properties: {
+          errors: { type: :string },
+        }, required: %w[errors]
+
+        run_test!
+      end
+    end
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -4,6 +4,63 @@ info:
   title: EMR API V1 DOCS
   version: v1
 paths:
+  "/api/v1/next_appointment":
+    get:
+      summary: list appointments
+      tags:
+      - Appointments
+      description: Appointments Endpoints
+      security:
+      - api_key: []
+      parameters:
+      - name: patient_id
+        in: query
+        example: 1
+        description: Patient ID
+        required: true
+        default: 1
+        schema:
+          type: integer
+      - name: program_id
+        in: query
+        example: 1
+        description: Program ID
+        required: true
+        default: 1
+        schema:
+          type: integer
+      - name: date
+        in: query
+        format: date
+        example: '2020-01-01'
+        description: Date in YYYY-MM-DD format
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  appointment_date:
+                    type: string
+                    format: date
+                required:
+                - appointment_date
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: string
+                required:
+                - errors
   "/api/v1/art_data_cleaning_tools":
     get:
       summary: Retrieve patients with data problems


### PR DESCRIPTION
A generic endpoint for next appointments

As usual checkout the swagger documentation for more details. It's under the Appointments Tag and currently the only endpoint under that tag