### PR TITLE
LIMS acknowledgement Fixes

### DIFF
--- a/app/models/lims_acknowledgement_status.rb
+++ b/app/models/lims_acknowledgement_status.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 # model for LIMS acknowledgement statuses
-class LimsAcknowledgementStatus < ApplicationRecord
+class LimsAcknowledgementStatus < VoidableRecord
+  self.table_name = :lims_acknowledgement_statuses
+  self.primary_key = :order_id
+
+  belongs_to :order, foreign_key: :order_id, optional: true
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -15,6 +15,7 @@ class Order < VoidableRecord
   validates_presence_of :patient_id, :concept_id, :encounter_id,
                         :provider, :orderer
   has_many :observations
+  has_one :lims_acknowledgement_status, foreign_key: :order_id
   has_one :drug_order
 
   validate :start_date
@@ -26,7 +27,8 @@ class Order < VoidableRecord
     errors.add(:start_date, ' cannot be in the future')
   end
 
-  def clear_dispensed_drugs(_void_reason)
+  def clear_dispensed_drugs(void_reason)
+    lims_acknowledgement_status&.void(void_reason)
     return unless drug_order
 
     drug_order.quantity = 0

--- a/bin/lab/fix_hanging_acknowledgements.rb
+++ b/bin/lab/fix_hanging_acknowledgements.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# fixes hanging acknowledgements whose orders have been voided
+
+def fix_hanging_acknowledgements
+  voided_orders.each do |order|
+    puts "Fixing hanging acknowledgement for order #{order['order_id']}"
+    acknowledgement = LimsAcknowledgementStatus.find(order['order_id'])
+    acknowledgement.update!(voided: order['voided'], voided_by: order['voided_by'], date_voided: order['date_voided'], void_reason: order['void_reason'])
+  end
+end
+
+def voided_orders
+  ActiveRecord::Base.connection.select_all <<~SQL
+    SELECT o.order_id, o.voided, o.void_reason, o.date_voided, o.voided_by
+    FROM orders o
+    WHERE o.voided = 1 AND o.order_id IN (#{LimsAcknowledgementStatus.all.collect(&:order_id).join(',')})
+  SQL
+end
+
+Rails.logger = Logger.new($stdout)
+ActiveRecord::Base.logger = Rails.logger
+ActiveRecord::Base.logger.level = :debug
+
+User.current = User.first
+
+ActiveRecord::Base.transaction do
+  fix_hanging_acknowledgements
+end

--- a/db/migrate/20230404133238_acknowledgement_voidable.rb
+++ b/db/migrate/20230404133238_acknowledgement_voidable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# migration to add voidable columns to LIMS acknowledgement statuses
+class AcknowledgementVoidable < ActiveRecord::Migration[5.2]
+  def change
+    # add the voided, voided_by, date_voided, void_reason columns
+    add_column :lims_acknowledgement_statuses, :voided, :boolean, default: false
+    add_column :lims_acknowledgement_statuses, :voided_by, :integer, default: nil
+    add_column :lims_acknowledgement_statuses, :date_voided, :datetime, default: nil
+    add_column :lims_acknowledgement_statuses, :void_reason, :string, default: nil
+
+    # voided by reference to user
+    add_foreign_key :lims_acknowledgement_statuses, :users, column: :voided_by, primary_key: :user_id
+  end
+end


### PR DESCRIPTION
Fixed the issues with orders that have been voided in the system. The voiding needs to affect the lims acknowledgement table as well. On site please run this command to fix all orders that have been voided. 

```bash
rails r ./bin/lab/fix_hanging_acknowledgements.rb 
```
## Please note that the above command only needs to be run once. Going forward any voiding of the order will automatically void the acknowledgement as well