### PR TITLE
Defaulter Report Fix

### DIFF
--- a/app/services/art_service/reports/cohort.rb
+++ b/app/services/art_service/reports/cohort.rb
@@ -125,6 +125,7 @@ module ARTService
 
           unless defaulter_date == 'N/A'
             next if defaulter_date < @start_date.to_date
+            next if defaulter_date > @end_date.to_date
           end
 
 


### PR DESCRIPTION
condition to remove those who default outside the bounds of the passed report period. This is in response to an issue that was reported on helpdesk on 17 April 2023

## Link to reported issue
https://egpafemr.sdpondemand.manageengine.com/app/itdesk/ui/requests/118246000013990003/details