### PR TITLE
pass program id to get obs for a specific program

### DIFF
--- a/app/controllers/api/v1/observations_controller.rb
+++ b/app/controllers/api/v1/observations_controller.rb
@@ -25,9 +25,12 @@ class Api::V1::ObservationsController < ApplicationController
   def index
     filters = params.permit(%i[person_id concept_id encounter_id order_id
                                value_coded value_datetime value_numeric
-                               accession_number value_text])
+                               accession_number value_text program_id])
+    program_id = filters.delete(:program_id)
 
     query = filters.empty? ? Observation : Observation.where(filters)
+
+    query = query.for_program(program_id) if program_id
 
     filter_period = index_filter_period
     query = query.where('obs_datetime BETWEEN ? AND ?', *filter_period) if filter_period

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -43,6 +43,12 @@ class Observation < VoidableRecord
     errors.add(:obs_datetime, ' cannot be in the future')
   end
 
+  scope(:for_program, lambda { |program_id|
+    return self if program_id.blank?
+
+    joins(:encounter).where(encounter: { program_id: program_id })
+  })
+
   scope(:recent, lambda { |number|
     joins(:encounter).order('obs_datetime DESC,date_created DESC').limit(number)
   })


### PR DESCRIPTION
Based on this [Helpdesk issue](https://egpafemr.sdpondemand.manageengine.com/app/itdesk/ui/requests/118246000013790071/details) system showing obs that are not for the same program