### PR TITLE
Fix on MOH Cohort Indicator 95

### DIFF
--- a/app/services/art_service/reports/cohort_builder.rb
+++ b/app/services/art_service/reports/cohort_builder.rb
@@ -354,8 +354,9 @@ module ARTService
 
         # Patients who started TPT in current reporting period
         tpt = Cohort::Tpt.new(start_date, end_date)
-        cohort_struct.newly_initiated_on_3hp = tpt.newly_initiated_on_3hp
-        cohort_struct.newly_initiated_on_ipt = tpt.newly_initiated_on_ipt
+        # tpt newly initiated has a property last_tpt_start_date we need to use that to get those clients
+        cohort_struct.newly_initiated_on_3hp = tpt.newly_initiated_on_3hp.select { |hash| hash['last_tpt_start_date'].nil? }
+        cohort_struct.newly_initiated_on_ipt = tpt.newly_initiated_on_ipt.select { |hash| hash['last_tpt_start_date'].nil? }
 
         puts "Started at: #{time_started}. Finished at: #{Time.now.strftime('%Y-%m-%d %H:%M:%S')}"
         cohort_struct


### PR DESCRIPTION
This fix is for indicator 95 on cohort report that was showing clients who have restarted TPT.

Previously the indicator was including clients who have restarted, now per definitions from M&E we are only showing clients who have started TPT in the quarter and have never taken TPT course before.

## How to reproduce it
1. Enter BDE mode say two years ago
2. Create a client and prescribe and dispense 6H (3HP can be tried too) for that will last for a month
3. Stop the treatment of TPT
4. Change the date to current or any quarter 6 months after step 1 above
5. Record a new visit of the client and prescribe them the same course
6. Now run a cohort report for the current visit quarter
7. On indicator 95 you will find the client appearing.
8. Now switch to this branch and regenerate the report the expected output is that the client should not appear

## Link to the reported Issue
https://egpafemr.sdpondemand.manageengine.com/app/itdesk/ui/requests/118246000013962161/details