### PR TITLE
Regimen Dispensation Report Bug

### DIFF
--- a/app/services/art_service/reports/regimen_dispensation_data.rb
+++ b/app/services/art_service/reports/regimen_dispensation_data.rb
@@ -7,8 +7,8 @@ module ARTService
       attr_reader :start_date, :end_date, :type
 
       def initialize(start_date:, end_date:, **kwargs)
-        @start_date = ActiveRecord::Base.connection.quote(start_date)
-        @end_date = ActiveRecord::Base.connection.quote(end_date)
+        @start_date = ActiveRecord::Base.connection.quote(start_date.to_date.strftime('%Y-%m-%d 00:00:00'))
+        @end_date = ActiveRecord::Base.connection.quote(end_date.to_date.strftime('%Y-%m-%d 23:59:59'))
         @type = kwargs[:type]
       end
 
@@ -202,6 +202,7 @@ module ARTService
             tcp.name regimen,
             trc.earliest_start_date
           FROM temp_patient_start_date trc
+          INNER JOIN temp_current_dispensation tcd ON tcd.patient_id = trc.patient_id AND tcd.start_date BETWEEN #{@start_date} AND #{@end_date}
           INNER JOIN person p ON p.person_id = trc.patient_id AND p.voided = 0
           INNER JOIN person_name pn ON pn.person_id = p.person_id AND pn.voided = 0
           LEFT JOIN patient_identifier i ON i.patient_id = p.person_id AND i.identifier_type = 4 AND i.voided = 0


### PR DESCRIPTION
## Bug
When you run this report for a given period (usually daily for clinical purposes) the report is bringing client who dispensation date are below the given start date

## How to Reproduce it
1. Switch to the development branch or any latest tag
2. Run the clinic regiment dispensation report
3. You will find clients outside the reported period
4. Now switch to this branch and rerun the report

## Expected Results
Should only show clients within the specified report period

## Helpdesk Ticket
https://egpafemr.sdpondemand.manageengine.com/app/itdesk/ui/requests/118246000014211141/details