### PR TITLE
TPT Completion for Split 3HP

### DIFF
--- a/app/services/art_service/reports/pepfar/tb_prev3.rb
+++ b/app/services/art_service/reports/pepfar/tb_prev3.rb
@@ -251,7 +251,8 @@ module ARTService
                   WHEN tpt_transfer_in_obs.value_numeric IS NOT NULL THEN 1
                   ELSE 0
                 END AS transfer_in,
-                MAX(o.start_date) AS last_dispensed_date
+                MAX(o.start_date) AS last_dispensed_date,
+                MAX(o.auto_expire_date) AS auto_expire_date
             FROM orders o
             INNER JOIN concept_name cn
               ON cn.concept_id = o.concept_id

--- a/app/services/art_service/reports/pepfar/utils.rb
+++ b/app/services/art_service/reports/pepfar/utils.rb
@@ -83,11 +83,14 @@ module ARTService
         end
 
         def patient_has_totally_completed_tpt?(patient, tpt)
-          patient['total_days_on_medication'].to_i >= if tpt == '3HP'
-                                                        80 # because we miss a single day with each DATEDIFF
-                                                      else
-                                                        176 # 6 months
-                                                      end
+          if tpt == '3HP'
+            init_date = patient['tpt_initiation_date'].to_date
+            end_date = patient['auto_expire_date'].to_date
+            days_on_medication = (end_date - init_date).to_i
+            days_on_medication >= 80
+          else
+            patient['total_days_on_medication'].to_i >= 176
+          end
         end
 
         ##


### PR DESCRIPTION
## Bug
Flagging clients taking split 3HP as completed after the second visit

## Steps to reproduce
1. Checkout to the development branch or the latest api tag
2. Create a client in BDE mode say in January 2023
3. And prescribe them monthly 3HP(RFP + INH)
4. On the third visit the system will flag the client as completed
5. Now switcht to this branch and do the same process

## Expected results
The system should not flag someone as completed on their second visit. They should flagged complete after their third visit

## Ticket
https://tasks.office.com/PEDAIDSORG.onmicrosoft.com/Home/Task/wAKztdTWvUGMu4CApRvH12UAIN2W?Type=TaskLink&Channel=Link&CreatedTime=638206819717810000
