### PR TITLE
Adding Missing VL Results to Data Cleaning Tool

### DIFF
--- a/app/services/art_service/data_cleaning_tool.rb
+++ b/app/services/art_service/data_cleaning_tool.rb
@@ -510,7 +510,7 @@ module ARTService
     def missing_vl_results
       ActiveRecord::Base.connection.select_all <<~SQL
         SELECT o.order_id, n.given_name, n.family_name, p.gender, p.birthdate, a.identifier arv_number,
-        i.identifier national_id, ord.accession_number, DATE(ord.start_date) start_date
+        i.identifier national_id, ord.accession_number, DATE(ord.start_date) start_date, p.person_id patient_id
         FROM obs o
         INNER JOIN orders ord ON ord.order_id = o.order_id AND ord.voided = 0
         INNER JOIN person p ON p.person_id = o.person_id AND p.voided = 0

--- a/app/services/art_service/data_cleaning_tool.rb
+++ b/app/services/art_service/data_cleaning_tool.rb
@@ -510,7 +510,7 @@ module ARTService
     def missing_vl_results
       ActiveRecord::Base.connection.select_all <<~SQL
         SELECT o.order_id, n.given_name, n.family_name, p.gender, p.birthdate, a.identifier arv_number,
-        i.identifier national_id, ord.accession_number, DATE(ord.start_date) start_date, p.person_id patient_id
+        i.identifier national_id, ord.accession_number, DATE(ord.start_date) order_date, p.person_id patient_id
         FROM obs o
         INNER JOIN orders ord ON ord.order_id = o.order_id AND ord.voided = 0
         INNER JOIN person p ON p.person_id = o.person_id AND p.voided = 0


### PR DESCRIPTION
We have added a report on missing VL results to the data cleaning tool.

## Sample Payload
It as an array of the following hashes
```bash
{
    "order_id": 4097631,
    "given_name": "Patient",
    "family_name": "One",
    "gender": "M",
    "birthdate": "1079-12-21",
    "arv_number": "N/A",
    "national_id": "N/A",
    "accession_number": "some_accession_number",
    "order_date": "2023-01-03",
    "patient_id": 143093
 }
```

## Tickets
https://tasks.office.com/PEDAIDSORG.onmicrosoft.com/Home/Task/uqyisdAugEKItw7c5_BVxGUAMCqA?Type=TaskLink&Channel=Link&CreatedTime=638209671404600000

## Pictures
![image](https://github.com/HISMalawi/BHT-EMR-API/assets/8115806/8f22f737-d214-409c-abb5-b9419aa8c8b9)
