### PR TITLE
MOH Cohort Report Section 54-57 Fix

### DIFF
--- a/app/services/art_service/reports/cohort_builder.rb
+++ b/app/services/art_service/reports/cohort_builder.rb
@@ -1349,14 +1349,14 @@ EOF
         registered = []
         if month_str == '4+ months'
           data = ActiveRecord::Base.connection.select_all(
-            "SELECT patient_id, died_in(t.patient_id, cum_outcome, date_enrolled) died_in FROM temp_patient_outcomes o
+            "SELECT patient_id, died_in(t.patient_id, cum_outcome, earliest_start_date) died_in FROM temp_patient_outcomes o
             INNER JOIN temp_earliest_start_date t USING(patient_id)
             WHERE cum_outcome = 'Patient died' GROUP BY patient_id
             HAVING died_in IN ('4+ months', 'Unknown')"
           )
         else
           data = ActiveRecord::Base.connection.select_all(
-            "SELECT patient_id, died_in(t.patient_id, cum_outcome, date_enrolled) died_in FROM temp_patient_outcomes o
+            "SELECT patient_id, died_in(t.patient_id, cum_outcome, earliest_start_date) died_in FROM temp_patient_outcomes o
             INNER JOIN temp_earliest_start_date t USING(patient_id)
             WHERE cum_outcome = 'Patient died' GROUP BY patient_id
             HAVING died_in = '#{month_str}'"


### PR DESCRIPTION
The current implementaion will now use the earliest start date to calculate the months someone died while taking medication.

The old version was using date enrolled which was causing miscalculations for those that have newly transferred in.

## Ticket Link
https://tasks.office.com/PEDAIDSORG.onmicrosoft.com/Home/Task/AmFHXSfMPkKx_9b1xl54YWUAOaxf?Type=TaskLink&Channel=Link&CreatedTime=638233830877020000