### PR TITLE
Bug Fix for TPT New Initiation Report

### DIFF
--- a/app/services/art_service/reports/cohort/tpt.rb
+++ b/app/services/art_service/reports/cohort/tpt.rb
@@ -58,6 +58,9 @@ class ARTService::Reports::Cohort::Tpt
     patients = []
     newly_initiated_on_tpt.each do |patient|
       course = patient['course'].match(/3HP/) ? '3HP' : 'IPT'
+      next if patient['last_course'].present?
+      next if patient['tpt_initial_start_date'].present? && patient['tpt_initial_start_date'].to_date < @start_date.to_date
+
       if patient['transfer_course'].blank? && patient['last_course'].blank?
         patients << patient
       elsif patient['transfer_course'].present? && patient['last_course'].blank?
@@ -127,6 +130,7 @@ class ARTService::Reports::Cohort::Tpt
         AND tpt_transfer_in_obs.concept_id = #{ConceptName.find_by_name('TPT Drugs Received').concept_id}
         AND tpt_transfer_in_obs.voided = 0
         AND tpt_transfer_in_obs.value_drug IN (SELECT drug_id FROM drug WHERE concept_id IN (SELECT concept_id FROM concept_name WHERE name IN ('Rifapentine', 'Isoniazid', 'Isoniazid/Rifapentine')))
+      -- Get the last TPT prescription
       LEFT JOIN (
         SELECT
           o.patient_id,


### PR DESCRIPTION
## Description
The definitions of Newly initiated has changed. In the past, the definition was also taking those restarted.

## How to replicate
Checkout to a latest tag and create a patients a month before the quarter you will be running the report. Given them a prescription of 3HP or 6H for 1 or 2 month respectively. The client should then break/miss 1 month or 2 months for 3HP or 6H respectively. Have them restart their prescription after the break.

Now run the cohort report and check section 95 (the expected behavior is that they shouldn't appear here. After running the cohort report, run the TPT Newly Initiated Report (this client will appear in that report), and the expected result is that these two reports will not consistent.

This can also be tested with those with a TPT drug transfer in.

## Test The Fix
Now switch to this branch and run the reports and again, and check if the report is now consistent. 