### PR TITLE
Bug Fix: Patient Searching When DDE is On

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -135,6 +135,8 @@ class Patient < VoidableRecord
   end
 
   def art_start_date
+    return nil if id.blank?
+
     result = ActiveRecord::Base.connection.select_one <<~SQL
       SELECT patient_start_date(#{id}) AS art_start_date
     SQL

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -142,6 +142,8 @@ class Patient < VoidableRecord
   end
 
   def tpt_status
+    return { tpt: nil, completed: false, tb_treatment: false, tpt_init_date: nil, tpt_complete_date: nil } if id.blank?
+    
     ARTService::Reports::Pepfar::TbPrev3.new(start_date: Date.today - 6.months, end_date: Date.today).patient_tpt_status(id)
   end
 end


### PR DESCRIPTION
## Description
When searching for clients the system is throwing an internal server error. This is happening when trying to convert the response into a JSON, the cause being the TPT status method that is always called for all patient model when being converted to JSON.

## How to replicate
Switch to the latest tag and connect the API to DDE, instructions on how to do this can be found on the README. Once this is done try to search for a client that surely DDE will  have and most likely the local database does not. You will then face this error.

## Fix
Now switch to this branch and do the same, the system will should proceed normally

## Pictures
![image](https://github.com/HISMalawi/BHT-EMR-API/assets/8115806/ad4e6de9-304b-4567-9a67-0b4f4bd2e466)
The users are failing to get a response here and proceed with their work