### PR TITLE
update radiology and ohsp gems to use rails 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ gem 'rswag-ui'
 # gem 'his_emr_api_radiology', '~> 0.0.8'
 
 gem 'his_emr_api_lab', git: 'https://github.com/EGPAFMalawiHIS/HIS-EMR-API-Lab', branch: 'upgrade/rails-7'
+gem 'emr_ohsp_interface', '~> 2.2.0'
+gem 'his_emr_api_radiology', '~> 1.0.9'
 
 gem 'parallel', '~> 1.20.1'
 


### PR DESCRIPTION
Update the 'radiology' and 'ohsp' gems to be compatible with Rails 7.
