### PR TITLE
rename age group to map unknowns

### DIFF
--- a/app/services/anc_service/reports/pepfar/pmtct_stat_art.rb
+++ b/app/services/anc_service/reports/pepfar/pmtct_stat_art.rb
@@ -25,7 +25,7 @@ module ANCService
           '80-84 years',
           '85-89 years',
           '90 plus years',
-          'Unknown age'
+          'Unknown'
         ].freeze
 
         def initialize(start_date:, end_date:, **_kwargs)


### PR DESCRIPTION
**Report Issue**
_refer to this jam for the bug_

https://jam.dev/c/015328d6-ab0c-47c9-9548-ba5bc7df5a58

> system was failing to map patients with unknown age

**Fix**

Rename the age group dict to match with age group coming from the query