### PR TITLE
TX TB Reworked

### DIFF
--- a/app/services/art_service/reports/pepfar/tx_tb.rb
+++ b/app/services/art_service/reports/pepfar/tx_tb.rb
@@ -1,92 +1,83 @@
-# rubocop:disable Metrics/BlockLength
+# frozen_string_literal: true
+
 module ARTService
   module Reports
     module Pepfar
+      # TxTB report
+      # rubocop:disable Metrics/ClassLength
       class TxTB
-        attr_accessor :start_date, :end_date, :report
+        attr_accessor :start_date, :end_date, :report, :rebuild_outcome
 
         include Utils
 
-        def initialize(start_date:, end_date:, **_kwargs)
+        def initialize(start_date:, end_date:, **kwargs)
           @start_date = start_date.to_date.strftime('%Y-%m-%d 00:00:00')
           @end_date = end_date.to_date.strftime('%Y-%m-%d 23:59:59')
+          @rebuild_outcome = ActiveModel::Type::Boolean.new.cast(kwargs[:rebuild_outcome]) || false
         end
 
-        # First of we need to get the patients who are alive and on treatment
-        # 1. We will rebuild the outcomes for the patients
-        # 2. We will get all clients who are 'On Antiretrovirals'
-        # 3. We will then get clients who have been screened for TB from the start_date to the end_date the become our denominator
-        # 4. Our numerator will be those clients who were TB confirmed and started on treatment (even though prior to this we where capturing the details)
         def find_report
           drop_temporary_tables
           init_report
-          ARTService::Reports::CohortBuilder.new(outcomes_definition: 'pepfar').init_temporary_tables(start_date, end_date)
-          clients_screened_for_tb
-          clients_confirmed_tb_and_on_treatment
-          tx_curr = find_patients_alive_and_on_art
-          tx_curr.each { |patient| report[patient['age_group']][patient['gender'].to_sym][:tx_curr] << patient['patient_id'] }
-          tb_screened.each do |patient|
-            next unless pepfar_age_groups.include?(patient['age_group'])
-            
-            report[age_group][patient['gender'].to_sym][:sceen_pos_new] << patient['patient_id'] if new_on_art(patient['enrollment_date']) && ['TB Suspected', 'sup'].include?(patient['tb_status'])
-            report[age_group][patient['gender'].to_sym][:sceen_neg_new] << patient['patient_id'] if new_on_art(patient['enrollment_date']) && ['TB NOT suspected', 'Nosup'].include?(patient['tb_status'])
-            report[age_group][patient['gender'].to_sym][:started_tb_new] << patient['patient_id'] if new_on_art(patient['enrollment_date']) && patient['tb_confirmed_date'].present?
-            report[age_group][patient['gender'].to_sym][:sceen_pos_prev] << patient['patient_id'] if !new_on_art(patient['enrollment_date']) && ['TB Suspected', 'sup'].include?(patient['tb_status'])
-            report[age_group][patient['gender'].to_sym][:sceen_neg_prev] << patient['patient_id'] if !new_on_art(patient['enrollment_date']) && ['TB NOT suspected', 'Nosup'].include?(patient['tb_status'])
-            report[age_group][patient['gender'].to_sym][:started_tb_prev] << patient['patient_id'] if !new_on_art(patient['enrollment_date']) && patient['tb_confirmed_date'].present?
-          end
+          build_cohort_tables
+          process_tb_screening
+          process_tb_confirmed_and_on_treatment
+          process_patients_alive_and_on_art
+          process_tb_screened
           report
         end
 
+        private
+
         def init_report
-          @report = pepfar_age_groups.each_with_object({}) do |age_group, report|
-            %i[M F].collect do |gender|
+          @report = initialize_report_structure
+        end
+
+        def initialize_report_structure
+          pepfar_age_groups.each_with_object({}) do |age_group, report|
+            genders = %i[M F]
+            genders.each do |gender|
               report[age_group] ||= {}
-              report[age_group][gender] = {
-                tx_curr: [],
-                sceen_pos_new: [],
-                sceen_neg_new: [],
-                started_tb_new: [],
-                sceen_pos_prev: [],
-                sceen_neg_prev: [],
-                started_tb_prev: []
-              }
+              report[age_group][gender] = initialize_gender_metrics
             end
           end
         end
 
+        def initialize_gender_metrics
+          {
+            tx_curr: [],
+            sceen_pos_new: [],
+            sceen_neg_new: [],
+            started_tb_new: [],
+            sceen_pos_prev: [],
+            sceen_neg_prev: [],
+            started_tb_prev: []
+          }
+        end
+
         def drop_temporary_tables
-          ActiveRecord::Base.connection.execute 'DROP TABLE IF EXISTS temp_tb_screened;'
-          ActiveRecord::Base.connection.execute 'DROP TABLE IF EXISTS temp_tb_confirmed_and_on_treatment;'
+          execute_action('DROP TABLE IF EXISTS temp_tb_screened;')
+          execute_action('DROP TABLE IF EXISTS temp_tb_confirmed_and_on_treatment;')
         end
 
-        def arv_concepts
-          @arv_concepts ||= ConceptSet.where(concept_set: ConceptName.where(name: 'Antiretroviral drugs')
-                                                                    .select(:concept_id))
-                                      .collect(&:concept_id).join(',')
+        def build_cohort_tables
+          return unless rebuild_outcome
+
+          cohort_builder = ARTService::Reports::CohortBuilder.new(outcomes_definition: 'pepfar')
+          cohort_builder.init_temporary_tables(start_date, end_date)
         end
 
-        def find_patients_alive_and_on_art
-          ActiveRecord::Base.connection.select_all <<~SQL
-            SELECT tpo.patient_id, LEFT(tesd.gender, 1) AS gender, disaggregated_age_group(tesd.birthdate, DATE('#{end_date.to_date}')) age_group
-            FROM temp_patient_outcomes tpo
-            INNER JOIN temp_earliest_start_date tesd ON tesd.patient_id = tpo.patient_id
-            WHERE tpo.cum_outcome = 'On antiretrovirals'
-          SQL
+        def process_tb_screening
+          execute_query(create_temp_tb_screened_query)
         end
 
-        def new_on_art(earliest_start_date)
-          earliest_start_date = earliest_start_date.to_date + 6.months
-          earliest_start_date >= end_date.to_date
-        end
-
-        def clients_screened_for_tb
-          ActiveRecord::Base.connection.select_all <<~SQL
+        def create_temp_tb_screened_query
+          <<~SQL
             CREATE TABLE temp_tb_screened AS
-            SELECT DISTINCT(o.person_id) as patient_id,
+            SELECT o.person_id as patient_id,
             LEFT(tesd.gender, 1) AS gender, MAX(o.obs_datetime) AS screened_date,
             tesd.earliest_start_date as enrollment_date,
-            disaggregated_age_group(tesd.birthdate, DATE(#{ActiveRecord::Base.connection.quote(end_date.to_date)})) AS age_group,
+            disaggregated_age_group(tesd.birthdate, DATE('#{end_date.to_date}')) AS age_group,
             (SELECT name FROM concept_name WHERE concept_id = o.value_coded AND o.voided = 0 LIMIT 1) AS tb_status
             FROM obs o
             INNER JOIN temp_earliest_start_date tesd ON tesd.patient_id = o.person_id
@@ -97,29 +88,103 @@ module ARTService
           SQL
         end
 
-        def clients_confirmed_tb_and_on_treatment
-          ActiveRecord::Base.connection.select_all <<~SQL
+        def process_tb_confirmed_and_on_treatment
+          execute_query(create_temp_tb_confirmed_query)
+        end
+
+        def create_temp_tb_confirmed_query
+          <<~SQL
             CREATE TABLE temp_tb_confirmed_and_on_treatment AS
-            SELECT o.person_id as patient_id, MIN(o.obs_datetime) AS tb_confirmed_date -- we might need to debate on this
+            SELECT o.person_id as patient_id, MIN(o.obs_datetime) AS tb_confirmed_date
             FROM obs o
             WHERE o.concept_id = #{ConceptName.find_by_name('TB status').concept_id}
             AND o.value_coded = #{ConceptName.find_by_name('Confirmed TB on treatment').concept_id}
             AND o.voided = 0
             AND o.obs_datetime BETWEEN '#{start_date}' AND '#{end_date}'
-            AND o.person_id IN(SELECT patient_id FROM temp_tb_screened)
+            AND o.person_id IN (SELECT patient_id FROM temp_tb_screened)
             GROUP BY o.person_id
           SQL
         end
 
-        def tb_screened
-          ActiveRecord::Base.connection.select_all <<~SQL
+        def process_patients_alive_and_on_art
+          find_patients_alive_and_on_art.each do |patient|
+            next unless pepfar_age_groups.include?(patient['age_group'])
+
+            @report[patient['age_group']][patient['gender'].to_sym][:tx_curr] << patient['patient_id']
+          end
+        end
+
+        def find_patients_alive_and_on_art
+          execute_query(create_patients_alive_and_on_art_query)
+        end
+
+        def create_patients_alive_and_on_art_query
+          <<~SQL
+            SELECT tpo.patient_id, LEFT(tesd.gender, 1) AS gender, disaggregated_age_group(tesd.birthdate, DATE('#{end_date.to_date}')) age_group
+            FROM temp_patient_outcomes tpo
+            INNER JOIN temp_earliest_start_date tesd ON tesd.patient_id = tpo.patient_id
+            WHERE tpo.cum_outcome = 'On antiretrovirals'
+          SQL
+        end
+
+        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/MethodLength
+        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/PerceivedComplexity
+        def process_tb_screened
+          tb_screened_data = find_tb_screened_data
+          tb_screened_data.each do |patient|
+            age_group = patient['age_group']
+            next unless pepfar_age_groups.include?(age_group)
+
+            gender = patient['gender'].to_sym
+            metrics = @report[age_group][gender]
+            enrollment_date = patient['enrollment_date']
+            tb_status = patient['tb_status'].downcase
+            tb_confirmed_date = patient['tb_confirmed_date']
+
+            if new_on_art(enrollment_date)
+              metrics[:sceen_pos_new] << patient['patient_id'] if ['tb suspected', 'sup'].include?(tb_status)
+              metrics[:sceen_neg_new] << patient['patient_id'] if ['tb not suspected', 'nosup'].include?(tb_status)
+              metrics[:started_tb_new] << patient['patient_id'] if tb_confirmed_date.present?
+            else
+              metrics[:sceen_pos_prev] << patient['patient_id'] if ['tb suspected', 'sup'].include?(tb_status)
+              metrics[:sceen_neg_prev] << patient['patient_id'] if ['tb not suspected', 'nosup'].include?(tb_status)
+              metrics[:started_tb_prev] << patient['patient_id'] if tb_confirmed_date.present?
+            end
+          end
+        end
+        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/MethodLength
+        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/PerceivedComplexity
+
+        def execute_query(query)
+          ActiveRecord::Base.connection.select_all(query)
+        end
+
+        def execute_action(query)
+          ActiveRecord::Base.connection.execute(query)
+        end
+
+        def find_tb_screened_data
+          execute_query(find_tb_screened_data_query)
+        end
+
+        def find_tb_screened_data_query
+          <<~SQL
             SELECT tbs.patient_id, tbs.enrollment_date, LEFT(tbs.gender, 1) AS gender, tbs.age_group, tbs.tb_status, tbs.screened_date, tbcot.tb_confirmed_date
             FROM temp_tb_screened tbs
             LEFT JOIN temp_tb_confirmed_and_on_treatment tbcot ON tbcot.patient_id = tbs.patient_id
           SQL
         end
+
+        def new_on_art(earliest_start_date)
+          six_months_later = earliest_start_date.to_date + 6.months
+          six_months_later > end_date.to_date
+        end
       end
+      # rubocop:enable Metrics/ClassLength
     end
   end
 end
-# rubocop:enable Metrics/BlockLength

--- a/app/services/art_service/reports/pepfar/tx_tb.rb
+++ b/app/services/art_service/reports/pepfar/tx_tb.rb
@@ -18,46 +18,25 @@ module ARTService
         # 3. We will then get clients who have been screened for TB from the start_date to the end_date the become our denominator
         # 4. Our numerator will be those clients who were TB confirmed and started on treatment (even though prior to this we where capturing the details)
         def find_report
+          drop_temporary_tables
           init_report
           ARTService::Reports::CohortBuilder.new(outcomes_definition: 'pepfar').init_temporary_tables(start_date, end_date)
+          clients_screened_for_tb
+          clients_confirmed_tb_and_on_treatment
           tx_curr = find_patients_alive_and_on_art
           tx_curr.each { |patient| report[patient['age_group']][patient['gender'].to_sym][:tx_curr] << patient['patient_id'] }
+          tb_screened.each do |patient|
+            next unless pepfar_age_groups.include?(patient['age_group'])
+            
+            report[age_group][patient['gender'].to_sym][:sceen_pos_new] << patient['patient_id'] if new_on_art(patient['enrollment_date']) && ['TB Suspected', 'sup'].include?(patient['tb_status'])
+            report[age_group][patient['gender'].to_sym][:sceen_neg_new] << patient['patient_id'] if new_on_art(patient['enrollment_date']) && ['TB NOT suspected', 'Nosup'].include?(patient['tb_status'])
+            report[age_group][patient['gender'].to_sym][:started_tb_new] << patient['patient_id'] if new_on_art(patient['enrollment_date']) && patient['tb_confirmed_date'].present?
+            report[age_group][patient['gender'].to_sym][:sceen_pos_prev] << patient['patient_id'] if !new_on_art(patient['enrollment_date']) && ['TB Suspected', 'sup'].include?(patient['tb_status'])
+            report[age_group][patient['gender'].to_sym][:sceen_neg_prev] << patient['patient_id'] if !new_on_art(patient['enrollment_date']) && ['TB NOT suspected', 'Nosup'].include?(patient['tb_status'])
+            report[age_group][patient['gender'].to_sym][:started_tb_prev] << patient['patient_id'] if !new_on_art(patient['enrollment_date']) && patient['tb_confirmed_date'].present?
+          end
+          report
         end
-
-        # def find_report
-        #   init_report
-        #   tx_curr = find_patients_alive_and_on_art
-        #   tx_curr.each { |patient| report[patient['age_group']][patient['gender'].to_sym][:tx_curr] << patient['patient_id'] }
-        #   screened = tb_screened(tx_curr.map { |patient| patient['patient_id'] })
-        #   pepfar_age_groups.each do |age_group|
-        #     screened.each do |patient|
-
-        #       next unless patient['age_group'] == age_group
-
-        #       start_date = patient['earliest_start_date']
-        #       enrollment_date = patient['date_enrolled']
-        #       tb_status_id = patient['tb_status']
-        #       gender = patient['gender'].to_sym
-
-        #       tb_status_name = ConceptName.find_by_concept_id(tb_status_id).name
-        #       next unless tb_status_name.present?
-
-        #       key_prefix = new_on_art(start_date, enrollment_date) ? :new : :prev
-
-        #       started_tb_key = :"started_tb_#{key_prefix}"
-        #       sceen_pos_key = :"sceen_pos_#{key_prefix}"
-        #       sceen_neg_key = :"sceen_neg_#{key_prefix}"
-        #       if ['RX', 'Confirmed TB on treatment'].include?(tb_status_name)
-        #         report[age_group][gender][started_tb_key] << patient['person_id']
-        #       elsif ['TB Suspected', 'Confirmed TB NOT on treatment', 'sup', 'Norx'].include?(tb_status_name)
-        #         report[age_group][gender][sceen_pos_key] << patient['person_id']
-        #       elsif tb_status_name == 'TB NOT suspected'
-        #         report[age_group][gender][sceen_neg_key] << patient['person_id']
-        #       end
-        #     end
-        #   end
-        #   report
-        # end
 
         def init_report
           @report = pepfar_age_groups.each_with_object({}) do |age_group, report|
@@ -76,6 +55,11 @@ module ARTService
           end
         end
 
+        def drop_temporary_tables
+          ActiveRecord::Base.connection.execute 'DROP TABLE IF EXISTS temp_tb_screened;'
+          ActiveRecord::Base.connection.execute 'DROP TABLE IF EXISTS temp_tb_confirmed_and_on_treatment;'
+        end
+
         def arv_concepts
           @arv_concepts ||= ConceptSet.where(concept_set: ConceptName.where(name: 'Antiretroviral drugs')
                                                                     .select(:concept_id))
@@ -84,29 +68,29 @@ module ARTService
 
         def find_patients_alive_and_on_art
           ActiveRecord::Base.connection.select_all <<~SQL
-            SELECT tpo.patient_id, tesd.gender, disaggregated_age_group(tesd.birthdate, DATE('#{end_date.to_date}')) age_group
+            SELECT tpo.patient_id, LEFT(tesd.gender, 1) AS gender, disaggregated_age_group(tesd.birthdate, DATE('#{end_date.to_date}')) age_group
             FROM temp_patient_outcomes tpo
             INNER JOIN temp_earliest_start_date tesd ON tesd.patient_id = tpo.patient_id
             WHERE tpo.cum_outcome = 'On antiretrovirals'
           SQL
         end
 
-        def new_on_art(earliest_start_date, min_date)
-          med_start_date = min_date.to_date
-          med_end_date = (earliest_start_date.to_date + 90.day).to_date
-
-          return true if med_start_date >= earliest_start_date.to_date && med_start_date < med_end_date
-
-          false
+        def new_on_art(earliest_start_date)
+          earliest_start_date = earliest_start_date.to_date + 6.months
+          earliest_start_date >= end_date.to_date
         end
 
         def clients_screened_for_tb
-          ActiveRecord::Base.connecton.select_all <<~SQL
-            CREATE TEMPORARY TABLE temp_tb_screened AS
-            SELECT DISTINCT(o.person_id) as patient_id, MAX(o.obs_datetime) AS screened_date, tesd.enrollment_date
+          ActiveRecord::Base.connection.select_all <<~SQL
+            CREATE TABLE temp_tb_screened AS
+            SELECT DISTINCT(o.person_id) as patient_id,
+            LEFT(tesd.gender, 1) AS gender, MAX(o.obs_datetime) AS screened_date,
+            tesd.earliest_start_date as enrollment_date,
+            disaggregated_age_group(tesd.birthdate, DATE(#{ActiveRecord::Base.connection.quote(end_date.to_date)})) AS age_group,
+            (SELECT name FROM concept_name WHERE concept_id = o.value_coded AND o.voided = 0 LIMIT 1) AS tb_status
             FROM obs o
             INNER JOIN temp_earliest_start_date tesd ON tesd.patient_id = o.person_id
-            WHERE o.concept = #{ConceptName.find_by_name('TB status').concept_id} 
+            WHERE o.concept_id = #{ConceptName.find_by_name('TB status').concept_id}
             AND o.voided = 0 AND o.value_coded IN (#{ConceptName.find_by_name('TB Suspected').concept_id}, #{ConceptName.find_by_name('TB NOT suspected').concept_id})
             AND o.obs_datetime BETWEEN '#{start_date}' AND '#{end_date}'
             GROUP BY o.person_id
@@ -115,10 +99,10 @@ module ARTService
 
         def clients_confirmed_tb_and_on_treatment
           ActiveRecord::Base.connection.select_all <<~SQL
-            CREATE TEMPORARY TABLE temp_tb_confirmed_and_on_treatment AS
-            SELECT o.person_id, MAX(o.obs_datetime) AS obs_datetime
+            CREATE TABLE temp_tb_confirmed_and_on_treatment AS
+            SELECT o.person_id as patient_id, MIN(o.obs_datetime) AS tb_confirmed_date -- we might need to debate on this
             FROM obs o
-            WHERE o.concept = #{ConceptName.find_by_name('TB status').concept_id}
+            WHERE o.concept_id = #{ConceptName.find_by_name('TB status').concept_id}
             AND o.value_coded = #{ConceptName.find_by_name('Confirmed TB on treatment').concept_id}
             AND o.voided = 0
             AND o.obs_datetime BETWEEN '#{start_date}' AND '#{end_date}'
@@ -127,16 +111,11 @@ module ARTService
           SQL
         end
 
-        def tb_screened(patient_ids)
-          return [] if patient_ids.blank?
-
+        def tb_screened
           ActiveRecord::Base.connection.select_all <<~SQL
-            SELECT DISTINCT p.person_id, p.gender, o.value_coded AS tb_status, disaggregated_age_group(p.birthdate, DATE(#{ActiveRecord::Base.connection.quote(end_date.to_date)})) AS age_group, earliest_start_date_at_clinic(p.person_id) AS earliest_start_date,
-            date_antiretrovirals_started(p.person_id, DATE(#{ActiveRecord::Base.connection.quote(end_date.to_date)})) AS date_enrolled
-            FROM person p
-            INNER JOIN obs o ON o.person_id = p.person_id and o.voided = 0
-            WHERE o.concept_id = #{ConceptName.find_by_name('TB status').concept_id}
-            AND p.person_id IN(#{patient_ids.join(",")})
+            SELECT tbs.patient_id, tbs.enrollment_date, LEFT(tbs.gender, 1) AS gender, tbs.age_group, tbs.tb_status, tbs.screened_date, tbcot.tb_confirmed_date
+            FROM temp_tb_screened tbs
+            LEFT JOIN temp_tb_confirmed_and_on_treatment tbcot ON tbcot.patient_id = tbs.patient_id
           SQL
         end
       end


### PR DESCRIPTION
Per the new definitions

1. We get the PEPFAR TX_CURR as at the end of reporting period
2. This TX_CURR is not a denominator
3. The denominator becomes all clients who were screened during the specified reporting period
4. The numerator becomes all the clients who were confirmed on TB during the specified time.

It is also important to note that all clients are only counted once with their latest screening and we take the minimum confirmed date within the specified period.

The definitions for new on ART is anyone on ART for less than 6 months.

The response object still remains the same.

## Things needed on the frontend
When a user clicks rebuild you might want to pass a rebuild_outcome property and set it to true @andie23 