### PR TITLE
TX TB

### DIFF
--- a/app/services/art_service/reports/pepfar/tx_tb.rb
+++ b/app/services/art_service/reports/pepfar/tx_tb.rb
@@ -103,6 +103,10 @@ module ARTService
               LEFT(p.gender, 1) AS gender,
               disaggregated_age_group(p.birthdate, DATE('#{end_date.to_date}')) AS age_group,
               COALESCE(MIN(tcd.value_datetime),MIN(o.obs_datetime)) AS tb_confirmed_date,
+              CASE
+                WHEN COUNT(tcd.value_datetime) > 0 THEN TRUE
+                ELSE FALSE
+              END AS has_tb_confirmed_date,
               tesd.earliest_start_date as enrollment_date,
               prev.tb_confirmed_date prev_reading
             FROM obs o
@@ -225,7 +229,7 @@ module ARTService
             SELECT t.patient_id, t.gender, t.age_group, t.enrollment_date, t.tb_confirmed_date
             FROM temp_tb_confirmed_and_on_treatment t
             WHERE t.tb_confirmed_date > '#{start_date}'
-            AND (t.prev_reading IS NULL OR TIMESTAMPDIFF(MONTH,t.prev_reading, t.tb_confirmed_date) > 6)
+            AND (t.has_tb_confirmed_date = TRUE OR t.prev_reading IS NULL OR TIMESTAMPDIFF(MONTH,t.prev_reading, t.tb_confirmed_date) > 6)
           SQL
         end
 


### PR DESCRIPTION
## Description
This fix adds a new definition to the TX_TB report. Previously the numerator was depended on the denominator and now this is totally independent.
1. Denominator all clients who were screened for TB during the reporting period irrespective of their outcomes
2. Numerator is all clients who were confirmed TB and on treatment

It is important to note that we are also considering if there's a record on when they started the TB and if this is not available we focus on whether they had the same status within six months prior to the start date of the reporting period. This 6 months periods might change but it is there to handle cases of confirmed TB and on treatment of like 10yrs ago from distorting the report.

The endpoints remain the same, the response structure remains the same.