### PR TITLE
Audit Trail Bug Fix

### DIFF
--- a/app/services/art_service/pharmacy/audit_trail.rb
+++ b/app/services/art_service/pharmacy/audit_trail.rb
@@ -157,6 +157,7 @@ module ARTService
 
         def transactions(from, to, transactions_date)
           query = ::Pharmacy.all
+          query = query.where("pharmacy_encounter_type_id != #{PharmacyEncounterType.find_by_name('Tins in previous stock').id}")
           query = query.where('DATE(pharmacy_obs.transaction_date) >= ?', from) if from
           query = query.where('DATE(pharmacy_obs.transaction_date) <= ?', to) if to
           query = query.where('DATE(pharmacy_obs.transaction_date) = ?', transactions_date) if transactions_date


### PR DESCRIPTION
## Description
The introduction of the 'Tins in previous stock' encounter type in the pharmacy obs table was causing distortions in the audit trail report. We are basically filtering out all those observation with that encounter type. The rest of the code remains the same.