### PR TITLE
Filing numbers

### DIFF
--- a/app/services/filing_number_service.rb
+++ b/app/services/filing_number_service.rb
@@ -369,7 +369,7 @@ class FilingNumberService
       ) orders_view
       INNER JOIN temp_potential_filing_number_candidates pi
         ON pi.patient_id = orders_view.patient_id
-      WHERE orders_view.start_date <= DATE(#{ActiveRecord::Base.connection.quote(date)}) - INTERVAL 240 DAY
+      WHERE orders_view.start_date <= DATE(#{ActiveRecord::Base.connection.quote(date)}) - INTERVAL 80 DAY
         AND orders_view.patient_id NOT IN (SELECT patient_id FROM temp_patient_with_adverse_outcomes)
       ORDER BY orders_view.start_date ASC
       LIMIT #{offset},#{limit}


### PR DESCRIPTION
## Description
Handling cases of low default options when chosing candidates for archiving. This was due to the large numbers of days we had put in the filter (because we were afraid and we wanted to be safe). Now we have reduced from 200+ days  to 80+. We hope with this more options will be available as archiving candidates to the providers. Unlike reassigning madness that is happening.

## Helpdesk Ticket
https://egpafemr.sdpondemand.manageengine.com/app/itdesk/ui/requests/118246000015229107/details