### PR TITLE
Encounters After Death

### DIFF
--- a/app/services/art_service/data_cleaning_tool.rb
+++ b/app/services/art_service/data_cleaning_tool.rb
@@ -399,7 +399,7 @@ module ARTService
           AND encounter.encounter_datetime >= DATE(deaths.death_date) + INTERVAL 1 DAY
           AND encounter.program_id = 1
           AND encounter.encounter_type NOT IN (
-            SELECT encounter_type_id FROM encounter_type WHERE name = 'HIV Reception'
+            SELECT encounter_type_id FROM encounter_type WHERE name = 'HIV Reception' OR name LIKE '%lab%'
           )
           AND encounter.voided = 0
         INNER JOIN person


### PR DESCRIPTION
# Description
This pull request addresses an issue reported on the helpdesk related to encounters following a patient's demise. Specifically, the problem arose when entering lab results after a patient's death, leading to these clients erroneously appearing in the data cleaning queries. In response to this issue, we have made enhancements to the query to include lab results filtering. Previously, the query only filtered the _**HIV RECEPTION**_ encounter post-death.

# Changes Made
To prevent errors in the system, given the unpredictable nature of user interactions, we have implemented a workflow that takes into account the vital status of the client. In addition to the warnings already presented by the frontend, the system will now withhold the provision of the next encounter if the client is confirmed as deceased.

Please note that this change does not restrict users from manually triggering encounters. They can still enter observations and encounters via the tasks pane in the frontend.

*Please review the changes in the code for further details.*

# Planner Ticket
https://tasks.office.com/PEDAIDSORG.onmicrosoft.com/Home/Task/j1syr--r20ekq9x1_3S-lGUALxlo?Type=TaskLink&Channel=Link&CreatedTime=638288088026970000

https://tasks.office.com/PEDAIDSORG.onmicrosoft.com/Home/Task/N4csN7ewMUe4aRy4t0F12WUALT4u?Type=TaskLink&Channel=Link&CreatedTime=638288088442730000

# Helpdesk Ticket
https://egpafemr.sdpondemand.manageengine.com/app/itdesk/ui/requests/118246000014815001/details?woFrom=ZSearchFeature