### PR TITLE
Fix Clinic VL Results Report to show clients with plasma specimen taken

### DIFF
--- a/app/services/art_service/reports/README.md
+++ b/app/services/art_service/reports/README.md
@@ -1,0 +1,16 @@
+# About Reports
+This folder contains the reports that are generated for the ART module. There are three main categories of reports in the EMR System namely
+- MOH
+- Clinic
+- PEPFAR
+
+## MOH
+The MOH reports are the reports that are generated for the Ministry of Health. These reports are generated in the format that is required by the Ministry of Health. Some of the reports that fall under other categories may depend on these reports for validations. These reports are requested and vetted by the Ministry. No report should be added to this category without written approval by the Ministry. Below is a list of all reports available in the system
+
+## Clinic
+The clinic reports are the reports that are generated for the clinic. These reports are generated in the format that is required by the clinic. Usually these are requested by the IP's and Clinic Personnel to aid in their daily. Below is a list of all clinic reports available in the system
+
+- [Viral Load Result](docs/viral_load_results.md) 
+
+### To Do
+** Some of the reports should be moved to the clinic folder and all references to them updated ** Make sure if we have gems that depends on this they are also update. Highly unlikely though

--- a/app/services/art_service/reports/docs/viral_load_results.md
+++ b/app/services/art_service/reports/docs/viral_load_results.md
@@ -1,0 +1,27 @@
+# Code Documentation
+
+## Summary
+The code snippet is a part of the ViralLoadResults class in the ARTService::Reports module. It is responsible for querying the database to find patients whose most recent viral load result falls within a specified range.
+
+## Example Usage
+```ruby
+report = ARTService::Reports::ViralLoadResults.new(start_date: '2021-01-01', range: 'suppressed')
+report.find_report
+```
+
+## Code Analysis
+### Inputs
+```start_date```: The start date of the reporting period.
+```end_date``` (optional): The end date of the reporting period. If not provided, it defaults to nil.
+range (optional): The viral load classification range. If not provided, it defaults to 'viraemia-1000+'.
+
+### Flow
+The ```initialize``` method sets the instance variables @start_date, @end_date, and @range based on the input parameters.
+The ```find_report``` method constructs a SQL query using the ActiveRecord select_all method to retrieve the required patient data from the database.
+The SQL query joins multiple tables (orders, concept_name, patient_identifier, person, obs) to retrieve the necessary information.
+The query filters the results based on the specified viral load classification range.
+The query groups the results by patient ID.
+The method returns the result of the SQL query.
+
+### Outputs
+The ```find_report``` method returns the result of the SQL query, which is a collection of patient data that matches the specified viral load classification range.

--- a/app/services/art_service/reports/viral_load_results.rb
+++ b/app/services/art_service/reports/viral_load_results.rb
@@ -40,7 +40,7 @@ module ARTService
           FROM orders
           INNER JOIN concept_name AS specimen_type
             ON specimen_type.concept_id = orders.concept_id
-            AND specimen_type.name IN ('Blood', 'DBS (Free drop to DBS card)', 'DBS (Using capillary tube)')
+            AND specimen_type.name IN ('Blood', 'DBS (Free drop to DBS card)', 'DBS (Using capillary tube)', 'Plasma')
             AND specimen_type.voided = 0
           LEFT JOIN patient_identifier
             ON patient_identifier.patient_id = orders.patient_id
@@ -83,7 +83,7 @@ module ARTService
               AND orders.order_type_id IN (SELECT order_type_id FROM order_type WHERE name = 'Lab' AND retired = 0)
               AND orders.concept_id IN (
                 SELECT concept_id FROM concept_name INNER JOIN concept USING (concept_id)
-                WHERE concept_name.name IN ('Blood', 'DBS (Free drop to DBS card)', 'DBS (Using capillary tube)')
+                WHERE concept_name.name IN ('Blood', 'DBS (Free drop to DBS card)', 'DBS (Using capillary tube)', 'Plasma')
                   AND concept.retired = 0 AND concept_name.voided = 0
               )
               AND orders.voided = 0

--- a/app/services/art_service/reports/viral_load_results.rb
+++ b/app/services/art_service/reports/viral_load_results.rb
@@ -117,7 +117,7 @@ module ARTService
 
       def specimen_types
         Concept.joins(:concept_names)
-               .merge(ConceptName.where(name: ['Blood', ]))
+               .merge(ConceptName.where(name: ['Blood']))
                .select(:concept_id)
                .to_sql
       end


### PR DESCRIPTION
##  Description
This PR fixes an issue where clients who had plasma specimen taken were not showing up in the Clinic VL Results Report. The issue was caused by a typo in the query that was used to fetch the results. The typo has been fixed and the report should now show all clients, regardless of the type of specimen that was taken.

## How to replicate
To replicate the issue switch to the latest tag, follow these steps:

1. Create two or three clients.
2. For each client, order a Viral Load Test.
3. Ensure that at least one of the clients has a plasma specimen taken.
4. Provide each client with their results.
5. Run the Clinic VL Results Report.

The client with the plasma specimen taken should not show up in the report.

Now switch to this branch and run the report again. The clients should appear.