### PR TITLE
Filing Number Reassignments

### DIFF
--- a/app/controllers/api/v1/patient_identifiers_controller.rb
+++ b/app/controllers/api/v1/patient_identifiers_controller.rb
@@ -91,40 +91,9 @@ class Api::V1::PatientIdentifiersController < ApplicationController
     secondary_patient_id  = params[:secondary_patient_id]
     identifier            = params[:identifier]
 
-    itype = PatientIdentifierType.find_by(name: 'Filing number')
+    result = service.swap_active_number(primary_patient_id: primary_patient_id, secondary_patient_id: secondary_patient_id, identifier: identifier)
 
-    PatientIdentifier.where(identifier_type: itype.id, patient_id: primary_patient_id).each do |i|
-      i.void("Voided by #{User.current.username}")
-    end
-
-    active_number = PatientIdentifier.create(patient_id: primary_patient_id,
-      identifier_type: itype.id, identifier: identifier, location_id: Location.current.id)
-
-    PatientIdentifier.where(identifier_type: itype.id, patient_id: secondary_patient_id).each do |i|
-      i.void("Voided by #{User.current.username}")
-    end
-
-
-
-    # ........................
-
-    itype = PatientIdentifierType.find_by(name: 'Archived filing number')
-    [primary_patient_id, secondary_patient_id].each do |id|
-      PatientIdentifier.where(identifier_type: itype.id, patient_id: id).each do |i|
-        i.void("Voided by #{User.current.username}")
-      end
-    end
-
-
-    filing_service = FilingNumberService.new
-    archive_identifier = filing_service.find_available_filing_number('Archived filing number')
-    archive_number = PatientIdentifier.create(patient_id: secondary_patient_id,
-      identifier_type: itype.id, identifier: archive_identifier, location_id: Location.current.id)
-
-    render json: {
-      active_number: identifier, primary_patient_id: primary_patient_id,
-      secondary_patient_id: secondary_patient_id, dormant_number: archive_identifier
-    }
+    render json: result
   end
 
   private

--- a/app/services/README.md
+++ b/app/services/README.md
@@ -1,0 +1,12 @@
+# Service Layer Documentation
+## Summary
+The service layer is a collection of modules that contain methods for performing common tasks. These methods are used by controllers and other modules to perform tasks such as creating and updating records, searching for data, and generating reports.
+
+## Example Usage
+```ruby
+# Find duplicates of a specific identifier type
+duplicates = PatientIdentifierService.find_duplicates(identifier_type)
+```
+
+## List of Services
+- [Patient Identifier Service](docs/patient_identifier_service.md)

--- a/app/services/docs/patient_identifier_service.md
+++ b/app/services/docs/patient_identifier_service.md
@@ -1,0 +1,39 @@
+# Code Documentation
+## Summary
+The code snippet is a part of the `PatientIdentifierService` module in Ruby. It contains several methods related to managing patient identifiers, such as finding duplicates, finding multiples, creating new identifiers, and swapping active numbers between patients.
+
+## Example Usage
+```ruby
+# Find duplicates of a specific identifier type
+duplicates = PatientIdentifierService.find_duplicates(identifier_type)
+
+# Find multiples of a specific identifier type
+multiples = PatientIdentifierService.find_multiples(identifier_type)
+
+# Create a new patient identifier
+params = { patient_id: 1, identifier_type: identifier_type, identifier: 'ABC123' }
+PatientIdentifierService.create(params)
+
+# Swap active numbers between two patients
+params = { primary_patient_id: 1, secondary_patient_id: 2, identifier: 'ABC123' }
+PatientIdentifierService.swap_active_number(params)
+```
+
+## Code Analysis
+### Inputs
+- `identifier_type`: An object representing the type of identifier to be searched, created, or swapped.
+___
+### Flow
+1. The `find_duplicates` method queries the database to find duplicate identifiers of a specific type.
+2. The `find_multiples` method fetches data about patients who have multiple identifiers of a specific type.
+3. The `create` method validates the new identifier, voids any existing identifier for the same patient and type, and creates a new identifier.
+4. The `swap_active_number` method validates the identifier assignment, voids filing numbers for both patients, and switches the active and archive numbers.
+___
+### Outputs
+- The `find_duplicates` method returns an array of hashes, each containing the count and identifier of a duplicate.
+- The `find_multiples` method returns an array of patient data, including their identifiers.
+- The `create` method returns the newly created identifier object.
+- The `swap_active_number` method returns a hash with details about the swapped numbers and patients.
+___
+
+[Back to Menu](../README.md)

--- a/app/services/patient_identifier_service.rb
+++ b/app/services/patient_identifier_service.rb
@@ -2,70 +2,133 @@
 
 module PatientIdentifierService
   class << self
-    ##
-    # Finds all duplicate identifiers of a given type.
-    #
-    # Returns an array of (identifier, count) pairs where the count is the
-    # number of duplicates found.
-    #
-    # @param {PatientIdentifierType} identifier_type
-    # @returns {Array<Array<string, integer>>}
     def find_duplicates(identifier_type)
       pid_type_id = ActiveRecord::Base.connection.quote(identifier_type.id)
+      query = <<~SQL
+        SELECT identifier, COUNT(identifier) AS `count`
+        FROM patient_identifier
+        WHERE voided = 0 AND identifier_type = #{pid_type_id}
+        GROUP BY identifier
+        HAVING COUNT(identifier) > 1
+      SQL
 
-      rows = ActiveRecord::Base.connection.select_all(
-        <<~SQL
-          SELECT identifier, count(identifier) AS `count` FROM patient_identifier
-          WHERE voided = 0 AND identifier_type = #{pid_type_id}
-          GROUP BY identifier HAVING count(identifier) > 1
-        SQL
-      )
-
-      rows.collect { |row| { count: row['count'], identifier: row['identifier'] } }
+      rows = ActiveRecord::Base.connection.select_all(query)
+      rows.map { |row| { count: row['count'], identifier: row['identifier'] } }
     end
 
     def find_multiples(identifier_type)
-      data = ActiveRecord::Base.connection.select_all <<~SQL
-        SELECT p.person_id patient_id, n.given_name, n.family_name, p.gender, p.birthdate, MAX(i.identifier) latest_identifier, COUNT(i.identifier) identifiers, GROUP_CONCAT(i.identifier) mutliple_identifiers
+      data = fetch_multiple_identifiers_data(identifier_type.id)
+      data.map do |row|
+        build_patient_data(row)
+      end
+    end
+
+    def create(params)
+      validate_identifier(params)
+      void_existing_identifier(params[:patient_id], params[:identifier_type])
+      create_new_identifier(params)
+    end
+
+    def swap_active_number(primary_patient_id:, secondary_patient_id:, identifier:)
+      validate_identifier_assignment(identifier)
+      void_filing_numbers(primary_patient_id, secondary_patient_id)
+      switch_active_and_archive_numbers(primary_patient_id, secondary_patient_id, identifier)
+    end
+
+    private
+
+    def identifier_already_assigned_today?(identifier:)
+      today = Time.now.beginning_of_day
+      PatientIdentifier.where(identifier: identifier).where('date_created >= ?', today).exists?
+    end
+
+    def fetch_multiple_identifiers_data(identifier_type_id)
+      query = <<~SQL
+        SELECT p.person_id patient_id, n.given_name, n.family_name, p.gender, p.birthdate,
+               MAX(i.identifier) latest_identifier, COUNT(i.identifier) identifiers,
+               GROUP_CONCAT(i.identifier) mutliple_identifiers
         FROM person p
-        INNER JOIN patient_identifier i ON i.patient_id = p.person_id AND i.identifier_type = #{identifier_type.id} AND i.voided = 0
+        INNER JOIN patient_identifier i ON i.patient_id = p.person_id AND i.identifier_type = #{identifier_type_id} AND i.voided = 0
         LEFT JOIN person_name n ON n.person_id = p.person_id AND n.voided = 0
         WHERE p.voided = 0
         GROUP BY p.person_id HAVING COUNT(i.identifier) > 1
         ORDER BY n.date_created DESC
       SQL
 
-      data.collect do |row|
-        {
-          patient_id: row['patient_id'],
-          given_name: row['given_name'],
-          family_name: row['family_name'],
-          gender: row['gender'],
-          birthdate: row['birthdate'],
-          latest_identifier: row['latest_identifier'],
-          identifiers: PatientIdentifier.where(identifier: row['mutliple_identifiers'].split(','), patient_id: row['patient_id'])
-        }
-      end
+      ActiveRecord::Base.connection.select_all(query)
     end
 
-    def create(params)
-      identifier = PatientIdentifier.find_by(identifier_type: params[:identifier_type],
-                                             identifier: params[:identifier])
-      if identifier
-        return identifier if identifier.patient_id == params[:patient_id]
+    def build_patient_data(row)
+      {
+        patient_id: row['patient_id'],
+        given_name: row['given_name'],
+        family_name: row['family_name'],
+        gender: row['gender'],
+        birthdate: row['birthdate'],
+        latest_identifier: row['latest_identifier'],
+        identifiers: PatientIdentifier.where(identifier: row['mutliple_identifiers'].split(','), patient_id: row['patient_id'])
+      }
+    end
 
-        raise InvalidParameterError, 'Identifier already assigned to another patient'
-      end
+    def validate_identifier(params)
+      identifier = PatientIdentifier.find_by(identifier_type: params[:identifier_type], identifier: params[:identifier])
+      return unless identifier && identifier.patient_id != params[:patient_id]
 
-      identifier = PatientIdentifier.find_by(patient_id: params[:patient_id],
-                                             identifier_type: params[:identifier_type])
+      raise InvalidParameterError, 'Identifier already assigned to another patient'
+    end
+
+    def void_existing_identifier(patient_id, identifier_type)
+      identifier = PatientIdentifier.find_by(patient_id: patient_id, identifier_type: identifier_type)
       identifier&.void("Updated to #{params[:identifier]} by #{User.current.username}")
+    end
 
+    def create_new_identifier(params)
       identifier = PatientIdentifier.new(params)
       identifier[:location_id] = Location.current.location_id
       identifier.save
-
       identifier
+    end
+
+    def validate_identifier_assignment(identifier)
+      return unless identifier_already_assigned_today?(identifier: identifier)
+
+      raise InvalidParameterError, 'Identifier already assigned to another patient'
+    end
+
+    def void_filing_numbers(primary_patient_id, secondary_patient_id)
+      void_identifier_type('Filing number', primary_patient_id, secondary_patient_id)
+      void_identifier_type('Archived filing number', primary_patient_id, secondary_patient_id)
+    end
+
+    def void_identifier_type(identifier_type_name, *patient_ids)
+      itype = PatientIdentifierType.find_by(name: identifier_type_name)
+      patient_ids.each do |id|
+        PatientIdentifier.where(identifier_type: itype.id, patient_id: id).each do |i|
+          i.void("Voided by #{User.current.username}")
+        end
+      end
+    end
+
+    def switch_active_and_archive_numbers(primary_patient_id, secondary_patient_id, identifier)
+      active_identifier = 'Filing number'
+      dormant_identifier = 'Archived filing number'
+
+      void_identifier_type(active_identifier, primary_patient_id, secondary_patient_id)
+
+      archive_identifier = FilingNumberService.new.find_available_filing_number(dormant_identifier)
+      create_patient_identifier(secondary_patient_id, archive_identifier, dormant_identifier)
+
+      {
+        active_number: identifier,
+        primary_patient_id: primary_patient_id,
+        secondary_patient_id: secondary_patient_id,
+        dormant_number: archive_identifier
+      }
+    end
+
+    def create_patient_identifier(patient_id, identifier, identifier_type_name)
+      itype = PatientIdentifierType.find_by(name: identifier_type_name)
+      PatientIdentifier.create(patient_id: patient_id, identifier_type: itype.id, identifier: identifier, location_id: Location.current.id)
     end
   end
 end


### PR DESCRIPTION
## Description
This PR handles the reported cased in Lighthouse managed Facilities where Filing Numbers get reassigned while clients are on the queue.

The providers are provided the same set of available Filing Numbers to choose from, this results in the current reassignment overiding the previous assignmet by another provider.

Inorder to handle these we are have implemented a check that kind of uses the MSSQL rowversions, in our case we are just using the date_created to prevent reassignment of the same identifier.

This is the first part of the solution to the problem with filing numbers. The second will be on optimizing the queries that fetch the available filing numbers for reassignment. For now this is quick solution.

It is important that the frontend team are aware of this and also implement ways of handling the response. @andie23

And yes I ended up refactoring the code as well