### PR TITLE
removed dublicates on the monthly activity report

### DIFF
--- a/app/services/hts_service/reports/clinic/hts_monthly_activity_log.rb
+++ b/app/services/hts_service/reports/clinic/hts_monthly_activity_log.rb
@@ -79,6 +79,7 @@ module HtsService
             left join obs p3 on p3.encounter_id = e.encounter_id and p3.voided = 0 and p3.concept_id = #{concept('Hepatitis B Test Result').concept_id} and e.encounter_type = #{testing_encounter}
             left join obs p4 on p4.encounter_id = e.encounter_id and p4.voided = 0 and p4.concept_id = #{concept('Recency Test').concept_id} and e.encounter_type = #{testing_encounter}
             where DATE(e.encounter_datetime) between '#{@start_date}' and '#{@end_date}'
+            GROUP BY p1.person_id,p2.person_id,p3.person_id,p4.person_id
           SQL
         end
       end

--- a/app/services/hts_service/reports/hts_report_builder.rb
+++ b/app/services/hts_service/reports/hts_report_builder.rb
@@ -1,105 +1,197 @@
 module HtsService
-  module Reports
-    module HtsReportBuilder
+    module Reports
+      module HtsReportBuilder
+  
+        def hts_age_groups
+          [
+            { less_than_one: "<1 year" },
+            { one_to_four: "1-4 years" },
+            { five_to_nine: "5-9 years" },
+            { ten_to_fourteen: "10-14 years" },
+            { fifteen_to_nineteen: "15-19 years" },
+            { twenty_to_twenty_four: "20-24 years" },
+            { twenty_five_to_twenty_nine: "25-29 years" },
+            { thirty_to_thirty_four: "30-34 years" },
+            { thirty_five_to_thirty_nine: "35-39 years" },
+            { fourty_to_fourty_four: "40-44 years" },
+            { fourty_five_to_fourty_nine: "45-49 years" },
+            { fifty_to_fifty_four: "50-54 years" },
+            { fifty_five_to_fifty_nine: "55-59 years" },
+            { sixty_to_sixty_four: "60-64 years" },
+            { sixty_five_to_sixty_nine: "65-69 years" },
+            { seventy_to_seventy_four: "70-74 years" },
+            { seventy_five_to_seventy_nine: "75-79 years" },
+            { eighty_to_eighty_four: "80-84 years" },
+            { eighty_five_to_eighty_nine: "85-89 years" },
+            { ninety_plus: "90 plus years" },
+          ].freeze
+        end
+  
+        def his_patients_rev
+          Patient.joins(:person, encounters: :program)
+                 .where(
+              encounter: {
+                encounter_datetime: @start_date..@end_date,
+                encounter_type: EncounterType.find_by_name("Testing"),
+              },
+              program: { program_id: Program.find_by_name("HTC PROGRAM").id },
+            )
+        end
 
-      def hts_age_groups
-        [
-          { less_than_one: "<1 year" },
-          { one_to_four: "1-4 years" },
-          { five_to_nine: "5-9 years" },
-          { ten_to_fourteen: "10-14 years" },
-          { fifteen_to_nineteen: "15-19 years" },
-          { twenty_to_twenty_four: "20-24 years" },
-          { twenty_five_to_twenty_nine: "25-29 years" },
-          { thirty_to_thirty_four: "30-34 years" },
-          { thirty_five_to_thirty_nine: "35-39 years" },
-          { fourty_to_fourty_four: "40-44 years" },
-          { fourty_five_to_fourty_nine: "45-49 years" },
-          { fifty_to_fifty_four: "50-54 years" },
-          { fifty_five_to_fifty_nine: "55-59 years" },
-          { sixty_to_sixty_four: "60-64 years" },
-          { sixty_five_to_sixty_nine: "65-69 years" },
-          { seventy_to_seventy_four: "70-74 years" },
-          { seventy_five_to_seventy_nine: "75-79 years" },
-          { eighty_to_eighty_four: "80-84 years" },
-          { eighty_five_to_eighty_nine: "85-89 years" },
-          { ninety_plus: "90 plus years" },
-        ].freeze
-      end
+  def his_patients_revs(indicators)
 
-      def his_patients_rev
-        Patient.joins(:person, encounters: :program)
-               .where(
-            encounter: {
-              encounter_datetime: @start_date..@end_date,
-              encounter_type: EncounterType.find_by_name("Testing"),
-            },
-            program: { program_id: Program.find_by_name("HTC PROGRAM").id },
-          )
-      end
-
-      def self_test_clients
-        Patient.joins(:person, encounters: [:observations, :program])
-               .merge(
-            Patient.joins(<<-SQL)
-          INNER JOIN encounter test ON test.voided = 0 AND test.patient_id = patient.patient_id
-          INNER JOIN obs visit ON visit.voided = 0 AND visit.person_id = person.person_id
+            columns = ActiveRecord::Base.connection.columns('obs').map(&:name) 
+          sql_query = <<~SQL
+            SELECT patients.patient_id, person.gender, person.birthdate, encounter.encounter_datetime,
+                   CONCAT_WS('/', #{columns.map { |col| "COALESCE(obs.#{col}, 'NULL')" }.join(', ')}) AS observations
+            FROM (
+                SELECT patient.patient_id
+                FROM patient
+                INNER JOIN person ON person.person_id = patient.patient_id AND patient.voided = 0 
+                INNER JOIN encounter ON encounter.patient_id = patient.patient_id
+                INNER JOIN program ON program.program_id = encounter.program_id
+                WHERE encounter.encounter_datetime BETWEEN '#{@start_date}' AND '#{@end_date}'
+                AND encounter.encounter_type = (
+                    SELECT encounter_type_id FROM encounter_type WHERE name = 'Testing'
+                )
+                AND program.program_id = (
+                    SELECT program_id FROM program WHERE name = 'HTC PROGRAM'
+                )
+            ) AS patients
+            INNER JOIN obs ON patients.patient_id = obs.person_id AND obs.voided = 0
+            INNER JOIN person ON person.person_id = patients.patient_id
+            INNER JOIN encounter ON encounter.patient_id = patients.patient_id;
           SQL
-          )
-          .where(
-            visit: { concept_id: concept("Visit type").concept_id, value_coded: concept("Self test distribution").concept_id },
-            encounter: {
-              encounter_datetime: @start_date..@end_date,
-              encounter_type: EncounterType.find_by_name("ITEMS GIVEN"),
-            },
-            program: { program_id: Program.find_by_name("HTC PROGRAM").id },
-          )
+        
+          results = ActiveRecord::Base.connection.execute(sql_query)
+        
+          data = {}
+        
+          results.each do |row|
+            patient_id = row[0]
+            observations = row[4].split('/')
+            patient_obs = {}
+        
+            columns.each_with_index do |value, index|
+              patient_obs[value] = observations[index]
+            end
+        
+            patient_data = data[patient_id]
+            if patient_data.nil?
+              patient_data = { "patientid" => patient_id, "observations" => [], "demographics" => { "gender" => row[1], "person_id" => patient_id, "birthdate" => row[2], "encounter_datetime" => row[3] } }
+              data[patient_id] = patient_data
+            end
+        
+            patient_data["observations"] << patient_obs
+          end
+        
+          return process_patient_data(data, indicators)
+    end
+        
+    def process_patient_data(data, indicators)
+          patient_data = []
+        
+          data.each do |_patient_id, patient_observation|
+            observations = patient_observation["observations"]
+            patient_obs = {}
+        
+            indicators.each do |indicator|
+              if indicator[:concept_id].is_a?(Integer)
+                desired_observation = observations.find { |obs| obs["concept_id"] == indicator[:concept_id].to_s }
+                if desired_observation.present?
+                  val = indicator[:value]
+                  name = indicator[:name]
+                  patient_obs[name] = (val == "value_numeric" ? desired_observation[val].to_i : desired_observation[val])
+                else
+                  patient_obs[name] = nil
+                end
+              elsif indicator[:concept_id].is_a?(Array)
+                indicator[:concept_id].each_with_index do |concept_id, index|
+                  desired_observation = observations.find { |obs| obs["concept_id"] == concept_id.to_s }
+                  if desired_observation.present?
+                    val = indicator[:value]
+                    name = indicator[:name][index]
+                    patient_obs[name] = (val == "value_numeric" ? desired_observation[val].to_i : desired_observation[val])
+                  else
+                    name = indicator[:name][index]
+                    patient_obs[name] = nil
+                  end
+                end
+              end
+            end
+        
+            patient_observation["demographics"].each do |key, value|
+              patient_obs["#{key}"] = value
+            end
+        
+            patient_data << patient_obs
+      end
+        
+         return patient_data
+   end
+
+   def self_test_clients
+          Patient.joins(:person, encounters: [:observations, :program])
+                 .merge(
+              Patient.joins(<<-SQL)
+            INNER JOIN encounter test ON test.voided = 0 AND test.patient_id = patient.patient_id
+            INNER JOIN obs visit ON visit.voided = 0 AND visit.person_id = person.person_id
+            SQL
+            )
+            .where(
+              visit: { concept_id: concept("Visit type").concept_id, value_coded: concept("Self test distribution").concept_id },
+              encounter: {
+                encounter_datetime: @start_date..@end_date,
+                encounter_type: EncounterType.find_by_name("ITEMS GIVEN"),
+              },
+              program: { program_id: Program.find_by_name("HTC PROGRAM").id },
+            )
+        end
       end
     end
   end
-end
-
-class ObsValueScope
-  # QUERY_STRING =
-  #   "%<join>s JOIN (
-  #         SELECT %<value>s, person_id
-  #         FROM obs
-  #         WHERE obs.voided = 0 AND obs.concept_id = %<concept_id>s
-  #       ) AS %<name>s ON %<name>s.person_id = person.person_id
-  #     ".freeze
-
-  QUERY_STRING =
-    <<~SQL
-      %<join>s JOIN obs %<name>s ON %<name>s.person_id = person.person_id
-      AND %<name>s.voided = 0
-      AND %<name>s.concept_id = %<concept_id>s
-    SQL
-    .freeze
-
-  def self.call(model:, name:, concept_id:, value: 'value_coded', join: 'INNER')
-    query = model
-    unless [name.class, concept_id.class].include?(Array)
-      return query.joins(format(QUERY_STRING,
-                                join: join,
-                                name: name,
-                                concept_id: concept_id,
-                                value: value))
-                  .select("#{name}.#{value} AS #{name}")
+  
+  class ObsValueScope
+    # QUERY_STRING =
+    #   "%<join>s JOIN (
+    #         SELECT %<value>s, person_id
+    #         FROM obs
+    #         WHERE obs.voided = 0 AND obs.concept_id = %<concept_id>s
+    #       ) AS %<name>s ON %<name>s.person_id = person.person_id
+    #     ".freeze
+  
+    QUERY_STRING =
+      <<~SQL
+        %<join>s JOIN obs %<name>s ON %<name>s.person_id = person.person_id
+        AND %<name>s.voided = 0
+        AND %<name>s.concept_id = %<concept_id>s
+      SQL
+      .freeze
+  
+    def self.call(model:, name:, concept_id:, value: 'value_coded', join: 'INNER')
+      query = model
+      unless [name.class, concept_id.class].include?(Array)
+        return query.joins(format(QUERY_STRING,
+                                  join: join,
+                                  name: name,
+                                  concept_id: concept_id,
+                                  value: value))
+                    .select("#{name}.#{value} AS #{name}")
+      end
+  
+      construct_query(model, name, concept_id, value, join)
     end
-
-    construct_query(model, name, concept_id, value, join)
-  end
-
-  def self.construct_query(model, name, concept_id, value, join)
-    query = model
-    concept_id.each_with_index do |concept, index|
-      query = query.joins(format(QUERY_STRING,
-                                 join: join,
-                                 name: name[index],
-                                 concept_id: concept,
-                                 value: value))
-                   .select("#{name[index]}.#{value} AS #{name[index]}")
+  
+    def self.construct_query(model, name, concept_id, value, join)
+      query = model
+      concept_id.each_with_index do |concept, index|
+        query = query.joins(format(QUERY_STRING,
+                                   join: join,
+                                   name: name[index],
+                                   concept_id: concept,
+                                   value: value))
+                     .select("#{name[index]}.#{value} AS #{name[index]}")
+      end
+      query
     end
-    query
   end
-end

--- a/app/services/hts_service/reports/moh/hts_initial_tested_for_hiv.rb
+++ b/app/services/hts_service/reports/moh/hts_initial_tested_for_hiv.rb
@@ -46,24 +46,24 @@ module HtsService
           {
             name: %w[test_one test_two test_three],
             concept_id: [concept(TEST_ONE).concept_id, concept(TEST_TWO).concept_id, concept(TEST_THREE).concept_id],
-            join: 'LEFT'
+            join: 'LEFT', value: 'value_coded'
           },
           { name: 'pregnancy_status', concept_id: concept(PREGNANCY_STATUS).concept_id, value: 'value_coded', join: 'LEFT' },
           { name: 'circumcision_status', concept_id: concept(CIRCUMCISION_STATUS).concept_id, value: 'value_coded', join: 'LEFT' },
           { name: 'male_condoms', concept_id: concept(MALE_CONDOMS).concept_id, join: 'LEFT', value: 'value_numeric' },
           { name: 'female_condoms', concept_id: concept(FEMALE_CONDOMS).concept_id, join: 'LEFT', value: 'value_numeric' },
           { name: 'frs', concept_id: concept(FRS).concept_id, join: 'LEFT', value: 'value_numeric' },
-          { name: 'referal_for_retesting', concept_id: concept(REFERRAL_FOR_RETESTING).concept_id, join: 'LEFT' },
+          { name: 'referal_for_retesting', concept_id: concept(REFERRAL_FOR_RETESTING).concept_id, join: 'LEFT', value: 'value_coded' },
           { name: 'time_of_hiv_test', concept_id: concept(TIME_OF_HIV_TEST).concept_id, value: 'value_datetime', join: 'LEFT' },
           { name: 'time_since_last_medication', value: 'value_datetime', concept_id: concept(TIME_SINCE_LAST_MEDICATION).concept_id, join: 'LEFT' },
-          { name: 'previous_hiv_test', concept_id: concept(PREVIOUS_HIV_TEST).concept_id, join: 'LEFT' },
-          { name: 'previous_hiv_test_done', concept_id: concept(PREVIOUS_HIV_TEST_DONE).concept_id, join: 'LEFT' },
-          { name: 'risk_category', concept_id: concept(RISK_CATEGORY).concept_id, join: 'LEFT' },
+          { name: 'previous_hiv_test', concept_id: concept(PREVIOUS_HIV_TEST).concept_id, join: 'LEFT', value: 'value_coded' },
+          { name: 'previous_hiv_test_done', concept_id: concept(PREVIOUS_HIV_TEST_DONE).concept_id, join: 'LEFT', value: 'value_coded' },
+          { name: 'risk_category', concept_id: concept(RISK_CATEGORY).concept_id, join: 'LEFT', value: 'value_coded' },
           { name: 'partner_present', concept_id: concept(PARTNER_PRESENT).concept_id, value: 'value_text', join: 'LEFT' },
-          { name: 'partner_hiv_status', concept_id: concept(PARTNER_HIV_STATUS).concept_id, join: 'LEFT' },
-          { name: 'taken_arvs_before', concept_id: concept(TAKEN_ARVS_BEFORE).concept_id, join: 'LEFT' },
-          { name: 'taken_prep_before', concept_id: concept(TAKEN_PREP_BEFORE).concept_id, join: 'LEFT' },
-          { name: 'taken_pep_before', concept_id: concept(TAKEN_PEP_BEFORE).concept_id, join: 'LEFT' },
+          { name: 'partner_hiv_status', concept_id: concept(PARTNER_HIV_STATUS).concept_id, join: 'LEFT', value: 'value_coded' },
+          { name: 'taken_arvs_before', concept_id: concept(TAKEN_ARVS_BEFORE).concept_id, join: 'LEFT', value: 'value_coded' },
+          { name: 'taken_prep_before', concept_id: concept(TAKEN_PREP_BEFORE).concept_id, join: 'LEFT', value: 'value_coded' },
+          { name: 'taken_pep_before', concept_id: concept(TAKEN_PEP_BEFORE).concept_id, join: 'LEFT', value: 'value_coded' },
           { name: 'referrals_ordered', concept_id: concept(REFERALS_ORDERED).concept_id, value: 'value_text', join: 'LEFT' },
         ]
 
@@ -133,6 +133,10 @@ module HtsService
         end
 
         def init_report
+          @query = his_patients_revs(INDICATORS) 
+        end
+=begin
+        def init_report
           model = his_patients_rev
           INDICATORS.each do |param|
             model = ObsValueScope.call(model: model, **param)
@@ -141,8 +145,9 @@ module HtsService
             model
               .select('person.gender, person.person_id, person.birthdate, encounter.encounter_datetime')
               .group('person.person_id, referrals_ordered.value_text')
-          ).to_hash
+          ).to_hash          
         end
+=end
 
         def set_unique
           @data.each do |key, obj|
@@ -203,6 +208,7 @@ module HtsService
 
           @data['syphilis_test_result_negative'] = filter_hash('syphilis_test_result', concept('Negative').concept_id)
           @data['syphilis_test_result_positive'] = filter_hash('syphilis_test_result', concept('Positive').concept_id)
+         
         end
 
         def fetch_pregnancy_test


### PR DESCRIPTION
In the monthly report, I found duplicates in the 'obs' table. Consequently, the query was retrieving all records for that person's concept. To address this issue, I have added a 'GROUP BY' condition to the query. Additionally, I will investigate why the front-end is able to push duplicate records.

Regarding the MoH Initial HIV Test report, I have written a new query.

I have used development as the base because that is the branch i cloned not HTS