### PR TITLE
ART COHORT INDICATOR FIXES

### DIFF
--- a/app/services/art_service/data_cleaning_tool.rb
+++ b/app/services/art_service/data_cleaning_tool.rb
@@ -176,7 +176,7 @@ module ARTService
           .map(&:drug_id)
     end
 
-    def prse_art_or_unknown_outcomes
+    def pre_art_or_unknown_outcomes
       data = ActiveRecord::Base.connection.select_all <<~SQL
         select
           p.patient_id

--- a/app/services/art_service/reports/cohort_builder.rb
+++ b/app/services/art_service/reports/cohort_builder.rb
@@ -930,7 +930,7 @@ module ARTService
               AND temp_patient_outcomes.cum_outcome = 'On antiretrovirals'
             WHERE voided = 0
               AND concept_id IN (#{bp_concepts.to_sql})
-              AND value_text IS NOT NULL
+              AND (value_text IS NOT NULL OR value_numeric IS NOT NULL)
               AND obs_datetime < DATE('#{end_date}') + INTERVAL 1 DAY
             GROUP BY person_id
           ) AS max_obs

--- a/app/services/art_service/reports/cohort_builder.rb
+++ b/app/services/art_service/reports/cohort_builder.rb
@@ -800,7 +800,7 @@ module ARTService
         external_concept = concept('External Consultation').concept_id
         hiv_clinic_registration_id = EncounterType.find_by_name('HIV CLINIC REGISTRATION').encounter_type_id
 
-        ActiveRecord::Base.connection.select_all("SELECT e.patient_id FROM temp_earliest_start_date e
+        ActiveRecord::Base.connection.select_all("SELECT e.patient_id FROM temp_cohort_members e
         LEFT JOIN encounter as hiv_registration ON hiv_registration.patient_id = e.patient_id AND hiv_registration.encounter_datetime < DATE(#{end_date}) AND hiv_registration.encounter_type = #{hiv_clinic_registration_id} AND hiv_registration.voided = 0
         LEFT JOIN (SELECT * FROM obs WHERE concept_id = #{type_of_patient_concept} AND voided = 0 AND value_coded = #{new_patient_concept} AND obs_datetime < DATE(#{end_date}) + INTERVAL 1 DAY) AS new_patient ON e.patient_id = new_patient.person_id
         LEFT JOIN (SELECT * FROM obs WHERE concept_id = #{type_of_patient_concept} AND voided = 0 AND value_coded = #{drug_refill_concept} AND obs_datetime < DATE(#{end_date}) + INTERVAL 1 DAY) AS refill ON e.patient_id = refill.person_id


### PR DESCRIPTION
## Description
This pull request addresses the following issues:

### ART Cohort Indicators
1. **BP Screened**
    - The BP screened indicator previously only considered text values, but the system now saves BP readings as numeric values. This pull request modifies the query to incorporate numeric values for accurate data analysis.

2. **Cumulative Indicator**
    - The cumulative indicator was incorrectly including emergency supply and external consultation data. This issue has been resolved, and the indicator now correctly calculates cumulative data.

### Data Cleaning Tool
1. **PRE ART OR UNKNOWN OUTCOMES**
    - There was a typographical error in the method name that prevented Ruby from finding the method. This pull request corrects the method name, ensuring the data cleaning tool functions as intended.
