### PR TITLE
Hypertension Report Fix

### DIFF
--- a/app/services/art_service/reports/clinic/hypertension_report.rb
+++ b/app/services/art_service/reports/clinic/hypertension_report.rb
@@ -152,7 +152,7 @@ module ARTService
                     WHEN sys.value_numeric > 179 THEN 'severe_reading'
                 END AS systolic_classification,
                 CASE
-                    WHEN dia.value_numeric < 89 THEN 'normal_reading'
+                    WHEN dia.value_numeric <= 89 THEN 'normal_reading'
                     WHEN dia.value_numeric > 89 AND dia.value_numeric <= 99 THEN 'mild_reading'
                     WHEN dia.value_numeric > 99 AND dia.value_numeric <= 109 THEN 'moderate_reading'
                     WHEN dia.value_numeric > 109 THEN 'severe_reading'


### PR DESCRIPTION
### Description
This pull request addresses an issue where a diastolic value of 89 was being missed in the hypertension report generation. It ensures that the API can handle diastolic readings of 89 without throwing an error.

### Changes Made
- Added a check for diastolic values of 89 in the code.
- Modified the API to handle diastolic values of 89 gracefully.

### Testing
To verify the changes, follow these steps:
1. Switch to the latest tag/release.
2. Provide a test client with a diastolic reading of 89.
3. Run the clinic hypertension report.
4. Note any errors or issues encountered.

Then, switch to this branch and perform the same test. The API is expected to handle diastolic values of 89 without errors and generate the report smoothly.

Feel free to test other values as well for both diastolic and systolic. Who knows you might find another bug! 

# You are way too awesome for reviewing this