### PR TITLE
added missing indicator

### DIFF
--- a/app/services/hts_service/reports/pepfar/hts_index.rb
+++ b/app/services/hts_service/reports/pepfar/hts_index.rb
@@ -37,6 +37,7 @@ module HtsService
               gender_sub_report[gender] = {
                 index_clients: [],
                 offered_index: [],
+                accepted_ait: [],
                 contacted_elicited: [],
                 facility: { new_positives: [], new_negatives: [], known_positives: [], documented_negatives: [] },
                 community: { new_positives: [], new_negatives: [], known_positives: [], documented_negatives: [] }
@@ -50,6 +51,7 @@ module HtsService
             report[patient['age_group']][patient['gender']][:index_clients] << patient['person_id']
             unless patient['consent'].blank?
               report[patient['age_group']][patient['gender']][:offered_index] << patient['person_id']
+              report[patient['age_group']][patient['gender']][:accepted_ait] << patient['person_id']
             end
             unless patient['consent'].blank?
               report[patient['age_group']][patient['gender']][:contacted_elicited] << { patient: patient['person_id'], contacts: patient['contacts']}


### PR DESCRIPTION
I have added the missing 'accepted_ait' indicator to the pepfar hts index report. I did not change the query because it seems to already capture patients with the 'consent_confirmation' value to 'YES.' Therefore, I concluded that those patients have accepted AIT.
