### PR TITLE
Visit By Changes

### DIFF
--- a/app/services/art_service/patient_visit.rb
+++ b/app/services/art_service/patient_visit.rb
@@ -151,7 +151,7 @@ module ARTService
 
     def visit_by
       if patient_present? && guardian_present?
-        'BOTH'
+        'Patient'
       elsif patient_present?
         'Patient'
       elsif guardian_present?


### PR DESCRIPTION
## Description
This change is due to a request by the Analyst team that we should not display BOTH for a visit type that both a guardian and patient came to the facility. So for all visits that both are available will be displayed as ```Patient``` visit.

## Ticket
[Shortcut Ticket](https://app.shortcut.com/mwemr/story/459/medication-given-is-labelled-both-when-dispensed-to-guardian-and-patient-it-should-be-either-patient-or-gardian-but-not-both)