### PR TITLE
 Fixes issues with fetching data for pregnant females

### DIFF
--- a/app/services/art_service/reports/cohort_builder.rb
+++ b/app/services/art_service/reports/cohort_builder.rb
@@ -1769,12 +1769,11 @@ EOF
                                    #{reason_for_starting_concept_id})
             AND obs.obs_datetime >= patients.earliest_start_date
             AND obs.obs_datetime < (patients.earliest_start_date + INTERVAL 1 DAY)
-            AND obs.value_coded IS NOT NULL
+            AND obs.value_coded IN (#{yes_concept_id},#{patient_preg_concept_id})
             AND obs.voided = 0
           WHERE patients.gender IN ('F', 'Female')
             AND patients.date_enrolled BETWEEN '#{start_date}' AND '#{end_date}'
-          GROUP BY patient_id
-          HAVING value_coded = #{yes_concept_id} OR value_coded = #{patient_preg_concept_id}
+          GROUP BY patient_id 
         SQL
 
         pregnant_at_initiation = ActiveRecord::Base.connection.select_all(


### PR DESCRIPTION
## Pull Request Description
### Summary

This pull request seeks to rectify issues encountered during the retrieval of data pertaining to pregnant females. The root cause of the problem was identified as the interaction between the `HAVING` clause and the `GROUP BY` clause, resulting in unexpected behavior. To address this, the `HAVING` clause has been removed from the relevant queries.

### Details

* Discovered and analyzed issues related to data retrieval for pregnant females.
* Determined that the interaction between the `GROUP BY` and `HAVING` clauses was the primary cause.
* Eliminated the `HAVING` clause to ensure consistent and accurate data retrieval.

### Potential Downside

The exclusion of the `HAVING` clause may introduce inconsistencies for clients concurrently utilizing the same indicators in both staging and consultation phases. To mitigate this, the development of a data cleaning tool is required, which will identify and resolve such cases.

### Testing

* Rigorous testing has been conducted to validate the functionality and accuracy of data retrieval post-implementation.

### Review

Your thoughtful review of this pull request is solicited. Please provide feedback, suggestions, or any concerns you may have.

### Additional Notes

* A separate task has been initiated to develop a dedicated data cleaning tool.
* Further documentation will be incorporated to address the potential downside and outline mitigation strategies.