### PR TITLE
Clinic Appointment Report Updates

### DIFF
--- a/app/services/program_appointment_service.rb
+++ b/app/services/program_appointment_service.rb
@@ -52,7 +52,7 @@ class ProgramAppointmentService
       i.identifier, p.birthdate, p.gender, n.given_name,
       n.family_name, obs.person_id, p.birthdate_estimated,att.value cell_phone,
       a.state_province district,
-      a.township_division village, a.city_village land_mark
+      a.township_division village, a.city_village land_mark, patient_outcome(obs.person_id, '#{date.strftime('%Y-%m-%d 23:59:59')}') outcome
     FROM obs
     INNER JOIN encounter e ON e.encounter_id = obs.encounter_id
     AND e.voided = 0 AND obs.voided = 0 AND e.program_id = #{program_id}
@@ -85,7 +85,8 @@ class ProgramAppointmentService
         birthdate: c['birthdate'], gender: c['gender'], person_id: c['person_id'],
         arv_number: c['identifier'], birthdate_estimated: c['birthdate_estimated'],
         cell_phone: c["cell_phone"], land_mark: c["land_mark"],
-        village: c["village"], district: c["district"]
+        village: c["village"], district: c["district"],
+        outcome: c["outcome"]
       }
     end
 


### PR DESCRIPTION
## Description
We have added an outcome indicator to the report. This is to just disntiguish those who are alive on treatment and those with adverse outcome. We hope it will help with clinic management, but currently we cannot remove those with adverse outcomes from the report until we are instructed to.

Below is  the new response.
```json
{
        "given_name": "John",
        "family_name": "Doe",
        "birthdate": "1972-09-09",
        "gender": "M",
        "person_id": 15900,
        "arv_number": "EXAMPLE-ARV-3527",
        "birthdate_estimated": 1,
        "cell_phone": "08 800 900",
        "land_mark": "America II   Residential Area",
        "village": "Area 51",
        "district": "Mexico City",
        "outcome": "On antiretrovirals"
}
```

## Known Issues
Since outcome are calculated yu will notice a slight delay unlike the old version.

## Tickets
[Ticket/Story 1062](https://app.shortcut.com/mwemr/story/1062/emr-issues-on-clients-with-to-but-appearing-on-booked-clients-helpdesk)