### PR TITLE
Odd Dispensations

### DIFF
--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -492,6 +492,19 @@ RSpec.configure do |config|
               returned_greater_than_3_months_and_less_than_6_months: { type: :array, items: { type: :integer } },
               returned_greater_than_or_equal_to_6_months: { type: :array, items: { type: :integer } }
             }
+          },
+          odd_dispensations: {
+            type: :object,
+            properties: {
+              patient_id: { type: :integer },
+              given_name: { type: :string },
+              family_name: { type: :string },
+              national_id: { type: :string },
+              arv_number: { type: :string },
+              gender: { type: :string },
+              birthdate: { type: :string, format: 'date-time' },
+              visit_dates: { type: :string, format: 'date-time' }
+            }
           }
         }
       },

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -3601,6 +3601,27 @@ components:
           type: array
           items:
             type: integer
+    odd_dispensations:
+      type: object
+      properties:
+        patient_id:
+          type: integer
+        given_name:
+          type: string
+        family_name:
+          type: string
+        national_id:
+          type: string
+        arv_number:
+          type: string
+        gender:
+          type: string
+        birthdate:
+          type: string
+          format: date-time
+        visit_dates:
+          type: string
+          format: date-time
 security:
 - api_key: []
 servers:


### PR DESCRIPTION
## Description
We have added this tool as a response to query of capturing clients who have had one or two visits after their adverse outcome. 

Endpoint 
```sh
/api/v1/art_data_cleaning_tools?date=2023-08-28&program_id=1&start_date=2023-01-01&end_date=2023-08-28&report_name=ODD DISPENSATIONS
```
Response is an array of these objects
```json
{
    "patient_id": 74,
    "given_name": "Jane",
    "family_name": "Doe",
    "national_id": "N9AHKD",
    "arv_number": "FN10310557",
    "gender": "F",
    "birthdate": "1966-11-25",
    "visit_dates": "2023-06-20"
}
```
## Images
This is the response schema in Swagger
![image](https://github.com/HISMalawi/BHT-EMR-API/assets/8115806/501b8d7c-4eea-4e87-b4fb-6380d32b7d2d)
