### PR TITLE
data cleaning pregnancy

### DIFF
--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -492,6 +492,19 @@ RSpec.configure do |config|
               returned_greater_than_3_months_and_less_than_6_months: { type: :array, items: { type: :integer } },
               returned_greater_than_or_equal_to_6_months: { type: :array, items: { type: :integer } }
             }
+          },
+          different_pregnancy_value_on_same_date: {
+            type: object,
+            properties: {
+              patient_id: { type: :integer },
+              given_name: { type: :string },
+              family_name: { type: :string },
+              visit_date: { type: :string, format: 'date-time' },
+              gender: { type: :string },
+              birthdate: { type: :string, format: 'date-time' },
+              arv_number: { type: :string },
+              national_id: { type: :string }
+            }
           }
         }
       },

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -494,7 +494,7 @@ RSpec.configure do |config|
             }
           },
           different_pregnancy_value_on_same_date: {
-            type: object,
+            type: :object,
             properties: {
               patient_id: { type: :integer },
               given_name: { type: :string },

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -3601,6 +3601,27 @@ components:
           type: array
           items:
             type: integer
+    different_pregnancy_value_on_same_date:
+      type: object
+      properties:
+        patient_id:
+          type: integer
+        given_name:
+          type: string
+        family_name:
+          type: string
+        visit_date:
+          type: string
+          format: date-time
+        gender:
+          type: string
+        birthdate:
+          type: string
+          format: date-time
+        arv_number:
+          type: string
+        national_id:
+          type: string
 security:
 - api_key: []
 servers:


### PR DESCRIPTION
## Description
We have added this tool as a way of explaining the large numbers that may come in on the Cohort female initialized on ART as pregant 

Endpoint 
```sh
/api/v1/art_data_cleaning_tools?date=2023-08-28&program_id=1&start_date=2023-01-01&end_date=2023-08-28&report_name=DIFFERENT PREGNANCY VALUE ON SAME DATE
```
Response is an array of these objects
```json
{
   "patient_id": 336,
    "given_name": "Jane",
    "family_name": "Doe",
    "visit_date": "2015-09-02",
    "gender": "F",
    "birthdate": "1977-04-05",
    "arv_number": "EXAMPLE",
    "national_id": "EXAMPLE"
}
```
## Reference
[This is the bug that has caused this](https://github.com/HISMalawi/BHT-EMR-API/pull/483)

## Images
This is the response schema in Swagger
![image](https://github.com/HISMalawi/BHT-EMR-API/assets/8115806/0fada832-d025-431c-9641-667ede0deeb1)