### PR TITLE
Tx New Report Outlier Fixes

### DIFF
--- a/app/services/art_service/reports/pepfar/tx_new.rb
+++ b/app/services/art_service/reports/pepfar/tx_new.rb
@@ -16,6 +16,7 @@ module ARTService
 
         def find_report
           report = init_report
+          addittional_groups report
           process_data report
           flatten_the_report report
         rescue StandardError => e
@@ -42,6 +43,18 @@ module ARTService
           end
         end
 
+        def addittional_groups(report)
+          report['All'] = {}
+          %w[M FP FNP FBf].each do |key|
+            report['All'][key] = {
+              cd4_less_than_200: [],
+              cd4_greater_than_equal_to_200: [],
+              cd4_unknown_or_not_done: [],
+              transfer_in: []
+            }
+          end
+        end
+
         def process_data(report)
           data.each do |row|
             age_group = row['age_group']
@@ -55,9 +68,28 @@ module ARTService
             new_patient = row['new_patient'].to_i
             patient_id = row['patient_id'].to_i
             earliest_start_date = row['earliest_start_date']
+            indicator = new_patient.positive? ? cd4_count_group : 'transfer_in'
 
-            report[age_group.to_s][gender.to_s][cd4_count_group.to_sym] << patient_id if new_patient.positive? && earliest_start_date.to_date >= start_date.to_date
-            report[age_group.to_s][gender.to_s]['transfer_in'.to_sym] << patient_id if new_patient.zero?
+            if new_patient.positive? && earliest_start_date.to_date >= start_date.to_date
+              report[age_group.to_s][gender.to_s][indicator.to_sym] << patient_id
+            end
+            report[age_group.to_s][gender.to_s][indicator.to_sym] << patient_id if new_patient.zero?
+            process_aggreggation_rows(report: report, gender: gender, indicator: indicator, start_date: earliest_start_date, patient_id: patient_id, maternal_status: row['maternal_status'], maternal_status_date: row['maternal_status_date'])
+          end
+        end
+
+        def process_aggreggation_rows(report:, gender:, indicator:, start_date:, **kwargs)
+          maternal_status = kwargs[:maternal_status]
+          maternal_status_date = kwargs[:maternal_status_date]
+
+          if gender == 'M'
+            report['All']['M'][indicator.to_sym] << kwargs[:patient_id]
+          elsif maternal_status&.match?(/pregnant/i) && maternal_status_date&.to_date == start_date.to_date
+            report['All']['FP'][indicator.to_sym] << kwargs[:patient_id]
+          elsif maternal_status&.match?(/breast/i) && maternal_status_date&.to_date == start_date.to_date
+            report['All']['FBf'][indicator.to_sym] << kwargs[:patient_id]
+          else
+            report['All']['FNP'][indicator.to_sym] << kwargs[:patient_id]
           end
         end
 
@@ -75,17 +107,20 @@ module ARTService
         def flatten_the_report(report)
           result = []
           report.each do |age_group, age_group_report|
-            result << process_age_group_report(age_group, 'M', age_group_report['M'])
-            result << process_age_group_report(age_group, 'F', age_group_report['F'])
+            age_group_report.each_key do |gender|
+              result << process_age_group_report(age_group, gender, age_group_report[gender])
+            end
           end
 
-          sorted_results = result.sort_by do |item|
-            gender_score = item[:gender] == 'F' ? 0 : 1
-            age_group_score = pepfar_age_groups.index(item[:age_group])
+          new_group = pepfar_age_groups.map { |age_group| age_group }
+          new_group.delete('Unknown')
+          new_group << 'All'
+          gender_scores = { 'F' => 0, 'M' => 1, 'FNP' => 3, 'FP' => 2, 'FBf' => 4 }
+          result.sort_by do |item|
+            gender_score = gender_scores[item[:gender]]
+            age_group_score = new_group.index(item[:age_group])
             [gender_score, age_group_score]
           end
-          # sort by gender, start all females and push all males to the end
-          sorted_results.sort_by { |h| [h[:gender] == 'F' ? 0 : 1] }
         end
 
         def data
@@ -107,7 +142,9 @@ module ARTService
                     ELSE 1
                 END new_patient,
                 pp.date_enrolled,
-                DATE(COALESCE(art_start_date.value_datetime, MIN(ord.start_date))) earliest_start_date
+                DATE(COALESCE(art_start_date.value_datetime, MIN(ord.start_date))) earliest_start_date,
+                preg_or_breast.name AS maternal_status,
+                DATE(MIN(pregnant_or_breastfeeding.obs_datetime)) AS maternal_status_date
             FROM patient_program pp
             INNER JOIN person pe ON pe.person_id = pp.patient_id AND pe.voided = 0
             INNER JOIN patient_state ps ON ps.patient_program_id = pp.patient_program_id AND ps.voided = 0 AND ps.start_date >= '#{start_date}' AND ps.state = 7   -- ON ART
@@ -133,6 +170,11 @@ module ARTService
                 AND transfer_in.voided = 0
                 AND transfer_in.value_coded = #{concept_name('Yes').concept_id}
                 AND DATE(transfer_in.obs_datetime) <= pp.date_enrolled
+            LEFT JOIN obs pregnant_or_breastfeeding ON pregnant_or_breastfeeding.person_id = pp.patient_id
+              AND pregnant_or_breastfeeding.concept_id IN (SELECT concept_id FROM concept_name WHERE name IN ('Breast feeding?', 'Breast feeding', 'Breastfeeding', 'Is patient pregnant?', 'patient pregnant') AND voided = 0)
+              AND pregnant_or_breastfeeding.voided = 0
+              AND pregnant_or_breastfeeding.value_coded = #{concept_name('Yes').concept_id}
+            LEFT JOIN concept_name preg_or_breast ON preg_or_breast.concept_id = pregnant_or_breastfeeding.concept_id AND preg_or_breast.voided = 0
             WHERE pp.program_id = #{program('HIV PROGRAM').id} AND pp.voided = 0 AND pp.date_enrolled <= DATE('#{end_date}') AND pp.date_enrolled >= DATE('#{start_date}')
             GROUP BY pp.patient_id
           SQL

--- a/app/services/art_service/reports/pepfar/tx_new.rb
+++ b/app/services/art_service/reports/pepfar/tx_new.rb
@@ -96,7 +96,11 @@ module ARTService
         def process_age_group_report(age_group, gender, age_group_report)
           {
             age_group: age_group,
-            gender: gender,
+            gender: if gender == 'F'
+                      'Female'
+                    else
+                      (gender == 'M' ? 'Male' : gender)
+                    end,
             cd4_less_than_200: age_group_report['cd4_less_than_200'.to_sym],
             cd4_greater_than_equal_to_200: age_group_report['cd4_greater_than_equal_to_200'.to_sym],
             cd4_unknown_or_not_done: age_group_report['cd4_unknown_or_not_done'.to_sym],
@@ -114,12 +118,14 @@ module ARTService
 
           new_group = pepfar_age_groups.map { |age_group| age_group }
           new_group << 'All'
-          gender_scores = { 'F' => 0, 'M' => 1, 'Male' => 2, 'FNP' => 4, 'FP' => 3, 'FBf' => 5 }
-          result.sort_by do |item|
+          gender_scores = { 'Female' => 0, 'Male' => 1, 'FNP' => 3, 'FP' => 2, 'FBf' => 4 }
+          result_scores = result.sort_by do |item|
             gender_score = gender_scores[item[:gender]]
             age_group_score = new_group.index(item[:age_group])
             [gender_score, age_group_score]
           end
+          # remove all unknown age groups
+          result_scores.reject { |item| item[:age_group].match?(/unknown/i) }
         end
 
         def data

--- a/app/services/art_service/reports/pepfar/tx_new.rb
+++ b/app/services/art_service/reports/pepfar/tx_new.rb
@@ -45,7 +45,7 @@ module ARTService
 
         def addittional_groups(report)
           report['All'] = {}
-          %w[M FP FNP FBf].each do |key|
+          %w[Male FP FNP FBf].each do |key|
             report['All'][key] = {
               cd4_less_than_200: [],
               cd4_greater_than_equal_to_200: [],
@@ -83,7 +83,7 @@ module ARTService
           maternal_status_date = kwargs[:maternal_status_date]
 
           if gender == 'M'
-            report['All']['M'][indicator.to_sym] << kwargs[:patient_id]
+            report['All']['Male'][indicator.to_sym] << kwargs[:patient_id]
           elsif maternal_status&.match?(/pregnant/i) && maternal_status_date&.to_date == start_date.to_date
             report['All']['FP'][indicator.to_sym] << kwargs[:patient_id]
           elsif maternal_status&.match?(/breast/i) && maternal_status_date&.to_date == start_date.to_date
@@ -113,9 +113,8 @@ module ARTService
           end
 
           new_group = pepfar_age_groups.map { |age_group| age_group }
-          new_group.delete('Unknown')
           new_group << 'All'
-          gender_scores = { 'F' => 0, 'M' => 1, 'FNP' => 3, 'FP' => 2, 'FBf' => 4 }
+          gender_scores = { 'F' => 0, 'M' => 1, 'Male' => 2, 'FNP' => 4, 'FP' => 3, 'FBf' => 5 }
           result.sort_by do |item|
             gender_score = gender_scores[item[:gender]]
             age_group_score = new_group.index(item[:age_group])


### PR DESCRIPTION
## Description
This PR addresses the issue of outliers in our data, which appear to be the result of incorrect data entry or potential data anomalies. We identified a specific case where a client was registered in the upcoming quarter, but had a BDE visit recorded in the current reporting quarter. Interestingly, this visit was not registered as an external visit.

To handle such scenarios and ensure data integrity, we have updated our query logic. This change was made in consensus with the team and will accommodate similar outlier scenarios in the future. This refinement aims to improve the accuracy of our reporting and data analysis.