### PR TITLE
Multiple Start Reasons Changes

### DIFF
--- a/app/services/art_service/data_cleaning_tool.rb
+++ b/app/services/art_service/data_cleaning_tool.rb
@@ -235,32 +235,37 @@ module ARTService
     end
 
     def multiple_start_reasons
-      concept_id = concept('Reason for ART eligibility').concept_id
-
-      data = ActiveRecord::Base.connection.select_all <<~SQL
-        SELECT person_id, count(concept_id) reason
-        FROM obs WHERE concept_id=#{concept_id} AND voided = 0
-        AND person_id NOT IN (#{external_clients})
-        GROUP BY person_id HAVING reason > 1;
-      SQL
-
-      return {} if data.blank?
-
-      patient_ids = data.map { |d| d['person_id'].to_i }
-
-      data = ActiveRecord::Base.connection.select_all <<~SQL
+      ActiveRecord::Base.connection.select_all <<~SQL
         SELECT
-          p.person_id, i.identifier arv_number, birthdate, gender, death_date,
-          n.given_name, n.family_name
-        FROM person p
-        LEFT JOIN patient_identifier i ON i.patient_id = p.person_id
-        AND i.identifier_type = #{indetifier_type} AND i.voided = 0
-        LEFT JOIN person_name n ON n.person_id = p.person_id AND n.voided = 0
-        WHERE p.person_id IN(#{patient_ids.join(',')})
-        GROUP BY p.person_id ORDER BY i.date_created DESC;
+          o.person_id patient_id,
+          a.identifier arv_number,
+          n.given_name,
+          n.family_name,
+          p.birthdate,
+          p.gender,
+          p.death_date,
+          GROUP_CONCAT(DISTINCT(vcn.name)) reasons,
+          GROUP_CONCAT(DISTINCT(DATE(o.obs_datetime))) visits
+        FROM obs o
+        INNER JOIN person p ON p.person_id = o.person_id AND p.voided = 0
+        INNER JOIN encounter e ON e.encounter_id = o.encounter_id AND e.voided = 0 AND e.program_id = 1 -- HIV Program
+        INNER JOIN concept_name cn ON cn.concept_id = o.concept_id AND cn.voided = 0 AND cn.concept_id = #{concept('Reason for ART eligibility').concept_id}
+        INNER JOIN concept_name vcn ON vcn.concept_id = o.value_coded AND vcn.voided = 0
+        INNER JOIN patient_program pp ON pp.patient_id = o.person_id AND pp.program_id = 1 AND pp.voided = 0
+        INNER JOIN patient_state ps ON ps.patient_program_id = pp.patient_program_id AND ps.voided = 0 AND ps.state = 7 -- On ART
+        INNER JOIN (
+          SELECT pp.patient_id, MIN(start_date) AS start_date
+          FROM patient_program pp
+          INNER JOIN patient_state ps ON ps.patient_program_id = pp.patient_program_id AND ps.voided = 0 AND ps.state = 7 -- On ART
+          WHERE pp.voided = 0 AND pp.program_id = 1 -- HIV Program
+          GROUP BY pp.patient_id
+        ) AS ms ON ms.patient_id = pp.patient_id AND ms.start_date = ps.start_date AND o.obs_datetime > ps.start_date
+        LEFT JOIN patient_identifier a ON a.patient_id = pp.patient_id AND a.voided = 0 AND a.identifier_type = #{indetifier_type}
+        LEFT JOIN person_name n ON n.person_id = pp.patient_id AND n.voided = 0
+        WHERE o.voided = 0
+        AND o.person_id NOT IN (#{external_clients})
+        GROUP BY o.person_id HAVING COUNT(DISTINCT(o.value_coded)) > 1 OR COUNT(DISTINCT(DATE(o.obs_datetime))) > 1;
       SQL
-
-      organise_data data
     end
 
     def missing_start_reasons


### PR DESCRIPTION
## Descriptions
* The logic that is used to pull clients with multiple reason has been updated. This is due to new insights that came through the PY4-Q1 QRM with Lighthouse. 

* The query has been updated to start checking mutliple start reason from the time a client starts treatment and not during PRE-ART state. Back then the providers were staging clients every visit and stopped when ART started.

## Bugs Fixed
* The queries was just hitting the obs table without checking whether the encounter was voided or not. This update uses a union with the encounter table to prevent these errors. 

* We might want to have another tool to clean these up. 

## Changes
* This the new payload. the payload is an array of objects below
```json
{
    "patient_id": 9808,
    "arv_number": "ARV_NUMBER/FILLING_NUMBER",
    "given_name": "John",
    "family_name": "Doe",
    "birthdate": "1761-10-06",
    "gender": "M",
    "death_date": null,
    "reasons": "WHO stage III adult,Unknown,Do not know,Don't know",
    "visits": "2007-12-28,2014-10-01"
}
```
* To avoid looping and multiple queries to the database, everything has been combined in one query. Below was the previous implementation after fetching for clients with multiple start reasons

```ruby
     patient_ids = data.map { |d| d['person_id'].to_i }

      data = ActiveRecord::Base.connection.select_all <<~SQL
        SELECT
          p.person_id, i.identifier arv_number, birthdate, gender, death_date,
          n.given_name, n.family_name
        FROM person p
        LEFT JOIN patient_identifier i ON i.patient_id = p.person_id
        AND i.identifier_type = #{indetifier_type} AND i.voided = 0
        LEFT JOIN person_name n ON n.person_id = p.person_id AND n.voided = 0
        WHERE p.person_id IN(#{patient_ids.join(',')})
        GROUP BY p.person_id ORDER BY i.date_created DESC;
      SQL

      organise_data data
```
## Suggestions
* Front-end to reflect the reasons and visits. Current Implementation
![image](https://github.com/HISMalawi/BHT-EMR-API/assets/8115806/546225fd-01d1-4f73-bb6d-3a2e502ba9bd)


## Tickets
https://app.shortcut.com/egpaf-2/story/1935/redefine-multiple-start-reasons-query