### PR TITLE
add data cleaning tool to flag patients missing birthdate

### DIFF
--- a/app/services/hts_service/data_cleaning.rb
+++ b/app/services/hts_service/data_cleaning.rb
@@ -17,6 +17,7 @@ module HTSService
       'DUPLICATE ENCOUNTERS' => 'duplicate_encounter',
       'PARTNER STATUS' => 'partner_status',
       'TEST DATE EARLIER THAN BIRTHDATE' => 'test_date_earlier_than_birthdate',
+      'MISSING BIRTHDATE' => 'missing_birthdate'      
     }.freeze
 
     def initialize(start_date, end_date, tool_name)
@@ -32,6 +33,34 @@ module HTSService
     end
 
     private
+
+    def missing_birthdate
+      ActiveRecord::Base.connection.select_all <<~SQL
+        SELECT
+          p.patient_id,
+          e.encounter_type,
+          i.identifier,
+          DATE(e.encounter_datetime) as visit_date,
+          pe.gender,
+          pe.birthdate,
+          pn.given_name,
+          pn.family_name
+        FROM patient p
+        INNER JOIN person_name pn ON pn.person_id = p.patient_id
+          AND pn.voided = 0
+        INNER JOIN person pe ON pe.person_id = p.patient_id
+          AND pe.voided = 0
+        INNER JOIN encounter e ON e.patient_id = p.patient_id
+          AND e.voided = 0
+        INNER JOIN patient_identifier i ON i.patient_id = p.patient_id AND i.identifier_type = #{patient_identifier_type('National id').id}
+        WHERE e.program_id = #{program('HTC PROGRAM').id}
+          AND e.voided = 0
+          AND DATE(e.encounter_datetime) >= DATE('#{@start_date}')
+          AND DATE(e.encounter_datetime) <= DATE('#{@end_date}')
+          AND pe.birthdate IS NULL
+          OR pe.birthdate = '0000-00-00'
+      SQL
+    end
 
     def incomplete_visits
       ActiveRecord::Base.connection.select_all <<~SQL


### PR DESCRIPTION
For some reason its noticed that some clients have a NULL birthdate in the system which is causing some reports to fail to generate

this tool will help flag out those clients so that they are updated and be able to generate the reports while we look for the cause of this