### PR TITLE
Fixes crashing issue when retrieving tpt status

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -172,7 +172,7 @@ class Patient < VoidableRecord
       order by orders.auto_expire_date desc
       limit 1
     SQL
-    result['auto_expire_date']&.to_date || nil
+    result['auto_expire_date']&.to_date || nil if !result.blank?
   end
 
   def tpt_status

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -172,7 +172,7 @@ class Patient < VoidableRecord
       order by orders.auto_expire_date desc
       limit 1
     SQL
-    result['auto_expire_date']&.to_date || nil if !result.blank?
+result['auto_expire_date']&.to_date || nil if result.present?
   end
 
   def tpt_status


### PR DESCRIPTION
## Context
Extra check has been added to prevent crashing when retrieving arv drug expire date.
Identified a client from MPC facility for whom the tpt_status endpoing would crash because date result hash is nil. This has been handled gracefully

## Reference
https://app.shortcut.com/egpaf-2/story/2779/backend-crashing-when-loading-tpt-status-on-consultation-page