### PR TITLE
TX TB Improvements

### DIFF
--- a/app/services/art_service/reports/pepfar/tx_tb.rb
+++ b/app/services/art_service/reports/pepfar/tx_tb.rb
@@ -15,6 +15,7 @@ module ArtService
           @end_date = end_date.to_date.strftime('%Y-%m-%d 23:59:59')
           @rebuild_outcome = ActiveModel::Type::Boolean.new.cast(kwargs[:rebuild_outcome]) || false
           @occupation = kwargs[:occupation]
+          @report_type = kwargs[:report_type] || 'moh'
         end
 
         def find_report
@@ -22,9 +23,9 @@ module ArtService
           create_temp_earliest_start_date unless temp_eartliest_start_date_exists?
           init_report
           build_cohort_tables
+          process_patients_alive_and_on_art
           process_tb_screening
           process_tb_confirmed_and_on_treatment
-          process_patients_alive_and_on_art
           process_tb_screened
           process_tb_confirmed
           report
@@ -69,7 +70,7 @@ module ArtService
         def build_cohort_tables
           return unless rebuild_outcome || @occupation.present?
 
-          cohort_builder = ArtService::Reports::CohortBuilder.new(outcomes_definition: 'pepfar')
+          cohort_builder = ArtService::Reports::CohortBuilder.new(outcomes_definition: @report_type)
           cohort_builder.init_temporary_tables(start_date, end_date, @occupation)
         end
 
@@ -91,17 +92,17 @@ module ArtService
             INNER JOIN (
               SELECT o.person_id, MAX(o.obs_datetime) AS obs_datetime, tesd.earliest_start_date, tesd.gender, tesd.birthdate
               FROM obs o
-              INNER JOIN temp_earliest_start_date tesd ON tesd.patient_id = o.person_id
+              INNER JOIN temp_earliest_start_date tesd ON tesd.patient_id = o.person_id #{@report_type == 'moh' ? '' : "AND tesd.patient_id IN (#{@tx_curr.join(',')})"}
               WHERE o.concept_id = #{ConceptName.find_by_name('TB status').concept_id}
               AND o.value_coded IN (SELECT concept_id FROM concept_name WHERE name IN ('TB Suspected', 'TB NOT suspected') AND voided = 0)
-              AND o.voided = 0 AND o.obs_datetime BETWEEN '#{start_date}' AND '#{end_date}'
+              AND o.voided = 0 AND o.obs_datetime BETWEEN '#{start_date}' AND '#{end_date}' #{@report_type == 'moh' ? '' : "AND o.person_id IN (#{@tx_curr.join(',')})"}
               GROUP BY o.person_id
             ) current_obs ON current_obs.person_id = o.person_id AND current_obs.obs_datetime = o.obs_datetime
             INNER JOIN concept_name cn ON cn.concept_id = o.value_coded AND cn.voided = 0
             LEFT JOIN obs screen_method ON screen_method.concept_id = #{ConceptName.find_by_name('TB screening method used').concept_id} AND screen_method.voided = 0 AND screen_method.person_id = o.person_id AND DATE(screen_method.obs_datetime) = DATE(current_obs.obs_datetime)
             LEFT JOIN concept_name vcn ON vcn.concept_id = screen_method.value_coded AND vcn.voided = 0 AND vcn.name IN ('CXR', 'MWRD')
             WHERE o.concept_id = #{ConceptName.find_by_name('TB status').concept_id}
-            AND o.voided = 0
+            AND o.voided = 0 #{@report_type == 'moh' ? '' : "AND o.person_id IN (#{@tx_curr.join(',')})"}
             AND o.value_coded IN (SELECT concept_id FROM concept_name WHERE name IN ('TB Suspected', 'TB NOT suspected') AND voided = 0)
             AND o.obs_datetime BETWEEN '#{start_date}' AND '#{end_date}'
             GROUP BY o.person_id
@@ -136,7 +137,7 @@ module ArtService
               tesd.earliest_start_date as enrollment_date,
               prev.tb_confirmed_date prev_reading
             FROM obs o
-            INNER JOIN temp_earliest_start_date tesd ON tesd.patient_id = o.person_id
+            INNER JOIN temp_earliest_start_date tesd ON tesd.patient_id = o.person_id #{@report_type == 'moh' ? '' : "AND tesd.patient_id IN (#{@tx_curr.join(',')})"}
             INNER JOIN person p ON p.person_id = o.person_id AND p.voided = 0
             LEFT JOIN obs tcd ON tcd.concept_id = #{ConceptName.find_by_name('TB treatment start date').concept_id} AND tcd.voided = 0 AND tcd.person_id = o.person_id
             LEFT JOIN (
@@ -147,7 +148,7 @@ module ArtService
               LEFT JOIN obs tcd ON tcd.concept_id = #{ConceptName.find_by_name('TB treatment start date').concept_id} AND tcd.voided = 0 AND tcd.person_id = o.person_id
               WHERE o.concept_id = #{ConceptName.find_by_name('TB status').concept_id}
               AND o.value_coded = #{ConceptName.find_by_name('Confirmed TB on treatment').concept_id}
-              AND o.voided = 0
+              AND o.voided = 0 #{@report_type == 'moh' ? '' : "AND o.person_id IN (#{@tx_curr.join(',')})"}
               AND o.obs_datetime <= '#{start_date}'
               GROUP BY o.person_id
             ) prev ON prev.person_id = o.person_id
@@ -160,10 +161,12 @@ module ArtService
         end
 
         def process_patients_alive_and_on_art
+          @tx_curr = []
           find_patients_alive_and_on_art.each do |patient|
             next unless pepfar_age_groups.include?(patient['age_group'])
 
             @report[patient['age_group']][patient['gender'].to_sym][:tx_curr] << patient['patient_id']
+            @tx_curr << patient['patient_id']
           end
         end
 
@@ -238,6 +241,7 @@ module ArtService
         # rubocop:enable Metrics/MethodLength
 
         def execute_query(query)
+          Rails.logger.info(query)
           ActiveRecord::Base.connection.select_all(query)
         end
 

--- a/app/services/art_service/reports/pepfar/tx_tb.rb
+++ b/app/services/art_service/reports/pepfar/tx_tb.rb
@@ -161,12 +161,12 @@ module ArtService
         end
 
         def process_patients_alive_and_on_art
-          @tx_curr = []
+          @tx_curr = [] if @report_type == 'pepfar'
           find_patients_alive_and_on_art.each do |patient|
             next unless pepfar_age_groups.include?(patient['age_group'])
 
             @report[patient['age_group']][patient['gender'].to_sym][:tx_curr] << patient['patient_id']
-            @tx_curr << patient['patient_id']
+            @tx_curr << patient['patient_id'] if @report_type == 'pepfar'
           end
         end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ Bundler.require(*Rails.groups)
 module BHTEmrApi
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.1
     config.eager_load_paths << Rails.root.join('lib')
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
# Description
We are moving the old TX_TB to MOH. The new TX_TB in PEPFAR Reports will be filtering clients based on TX_CURR. Frontend will need to ```report_type``` parameter for the API to know how to respond for MOH and PEPFAR requests. The allowed values are
1. pepfar
2. moh

New Endpoint
```curl
HOST:PORT/api/v1/programs/1/reports/tx_tb?date=2024-03-28&program_id=1&start_date=2023-10-01&end_date=2023-12-31&rebuild_outcome=false&report_type=pepfar
```

# Ticket
[Shortcut](https://app.shortcut.com/egpaf-2/story/2825/develop-a-tx-tb-report-for-pepfar-that-disaggregates-filters-all-data-elements-based-on-txcurr-at-the-end-of-the-reporting)