### PR TITLE
Regimen Distribution Bug Fix

### DIFF
--- a/app/services/art_service/reports/regimens_by_weight_and_gender.rb
+++ b/app/services/art_service/reports/regimens_by_weight_and_gender.rb
@@ -36,7 +36,7 @@ module ArtService
       ].freeze
 
       def regimen_counts
-        with_lock(Cohort::LOCK_FILE) do
+        with_lock(ArtCohort::LOCK_FILE) do
           PatientsAliveAndOnTreatment.new(start_date:, end_date:, occupation: @occupation)
                                      .refresh_outcomes_table
 


### PR DESCRIPTION
## Description
When running MOH Regimen Distribution report people where facing this error: ```#<NameError: uninitialized constant ArtService::Reports::Cohort::LOCK_FILE>```. This has now been resolved. It was reference issue.

## Ticket
[Shortcut](https://app.shortcut.com/egpaf-2/story/2868/moh-regimen-distribution-weight-error-api-error-internal-server-error)