### PR TITLE
TxNew Fix: Double counting transfer in

### DIFF
--- a/app/services/art_service/reports/pepfar/tx_new.rb
+++ b/app/services/art_service/reports/pepfar/tx_new.rb
@@ -93,7 +93,6 @@ module ArtService
             else
               next
             end
-            report[age_group.to_s][gender.to_s][indicator.to_sym] << patient_id if new_patient.zero?
             process_aggreggation_rows(report:, gender:, indicator:, start_date: date_enrolled,
                                       patient_id:, maternal_status: row['maternal_status'], maternal_status_date: row['maternal_status_date'])
           end


### PR DESCRIPTION
## Context
Transfer in column results were duplicating the same client

## Description
The code seems to have redundant assignment of transfer in clients. I have deleted the offending code. @Skipper-116 Please verify if that line was intentional

## Screenshots
![double counting transferins](https://github.com/HISMalawi/BHT-EMR-API/assets/18445154/9b5f10c8-44bb-4c38-97d4-69b97df2955d)
