### PR TITLE
Cxca tx fix

### DIFF
--- a/app/services/cxca_service/reports/clinic/monthly_cecap_tx.rb
+++ b/app/services/cxca_service/reports/clinic/monthly_cecap_tx.rb
@@ -19,8 +19,8 @@ module CxcaService
         TREATMENTS = %i[thermocoagulation cryotherapy leep].freeze
 
         def initialize(start_date:, end_date:)
-          @start_date = start_date.to_date.beginning_of_day
-          @end_date = end_date.to_date.end_of_day
+          @start_date = start_date.to_date.beginning_of_day.strftime('%Y-%m-%d %H:%M:%S')
+          @end_date = end_date.to_date.end_of_day.strftime('%Y-%m-%d %H:%M:%S')
           @report = {}
         end
 

--- a/app/services/cxca_service/reports/clinic/monthly_screen_report.rb
+++ b/app/services/cxca_service/reports/clinic/monthly_screen_report.rb
@@ -25,8 +25,8 @@ module CxcaService
         TREATMENTS = %i[thermocoagulation cryotherapy leep].freeze
 
         def initialize(start_date:, end_date:)
-          @start_date = start_date.to_date.beginning_of_day
-          @end_date = end_date.to_date.end_of_day
+          @start_date = start_date.to_date.beginning_of_day.strftime('%Y-%m-%d %H:%M:%S')
+          @end_date = end_date.to_date.end_of_day.strftime('%Y-%m-%d %H:%M:%S')
           @report = {}
         end
 

--- a/app/services/cxca_service/reports/pepfar/cxca_scrn.rb
+++ b/app/services/cxca_service/reports/pepfar/cxca_scrn.rb
@@ -24,8 +24,8 @@ module CxcaService
         }.freeze
 
         def initialize(start_date:, end_date:)
-          @start_date = start_date.to_date.beginning_of_day
-          @end_date = end_date.to_date.end_of_day
+          @start_date = start_date.to_date.beginning_of_day.strftime('%Y-%m-%d %H:%M:%S')
+          @end_date = end_date.to_date.end_of_day.strftime('%Y-%m-%d %H:%M:%S')
           @report = {}
         end
 

--- a/app/services/cxca_service/reports/pepfar/cxca_tx.rb
+++ b/app/services/cxca_service/reports/pepfar/cxca_tx.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/AbcSize, Style/Documentation
 # frozen_string_literal: true
 
 module CxcaService
@@ -31,7 +32,7 @@ module CxcaService
         private
 
         def init_report
-          query = fetch_query.to_hash
+          query = fetch_query
           pepfar_age_groups.collect do |age_group|
             row = {}
             row['age_group'] = age_group
@@ -47,7 +48,7 @@ module CxcaService
           end
         end
 
-        def fetch_query
+        def fetch_query # rubocop:disable Metrics/MethodLength
           Person.connection.select_all(
             Person.joins(patient: :encounters)
               .where(encounter: { program_id: CxCa_PROGRAM.id, encounter_datetime: @start_date..@end_date })
@@ -62,7 +63,10 @@ module CxcaService
                 AND reason_name.voided = 0
               SQL
               .group('person.person_id')
-              .select("disaggregated_age_group(person.birthdate, DATE('#{@end_date.to_date}')) AS age_group, person.person_id, reason_name.name AS reason_for_visit, treatment.value_text AS treatment")
+              .select("disaggregated_age_group(person.birthdate, DATE('#{@end_date.to_date}')) AS age_group,
+                      person.person_id,
+                      reason_name.name AS reason_for_visit,
+                      treatment.value_text AS treatment")
               .to_sql
           )
         end
@@ -70,3 +74,5 @@ module CxcaService
     end
   end
 end
+
+# rubocop:enable Metrics/AbcSize, Style/Documentation

--- a/app/services/cxca_service/reports/pepfar/cxca_tx.rb
+++ b/app/services/cxca_service/reports/pepfar/cxca_tx.rb
@@ -20,8 +20,8 @@ module CxcaService
         TREATMENTS = %i[thermocoagulation cryotherapy leep].freeze
 
         def initialize(start_date:, end_date:)
-          @start_date = start_date.to_date.beginning_of_day
-          @end_date = end_date.to_date.end_of_day
+          @start_date = start_date.to_date.beginning_of_day.strftime('%Y-%m-%d %H:%M:%S')
+          @end_date = end_date.to_date.end_of_day.strftime('%Y-%m-%d %H:%M:%S')
           @report = {}
         end
 


### PR DESCRIPTION
## Context
API was returning MYSQL error: *Mysql2::Error: Incorrect date value: '2024-03-31 23:59:59 +0200' for column 'end_date' at row 1*. this was cased by the implementation of the date formats *start_date.to_date.beginning_of_day* which cased the dates to come like *'2024-03-31 23:59:59 +0200*

## Changes in the codebase
*Explicitly format the date string to mysql compartible format.*

## Ticket
[Here](https://app.shortcut.com/egpaf-2/story/3056/mysql2-error-incorrect-date-value-2024-03-31-23-59-59-0200-for-column-end-date-at-row-1-on-cxca-pepfar-reports)