### PR TITLE
fix breaking condition

### DIFF
--- a/app/services/anc_service/reports/cohort_builder.rb
+++ b/app/services/anc_service/reports/cohort_builder.rb
@@ -392,7 +392,9 @@ module AncService
         encounter_types = ['LAB RESULTS', 'ART_FOLLOWUP'].collect { |t| EncounterType.find_by_name(t).id }
         art_answers = ['Yes', 'Already on ART at another facility']
 
-        if type === 'monthly'
+        result = []
+
+        if type == 'monthly'
 
           result = begin
             Encounter.find_by_sql(['SELECT e.patient_id FROM encounter e
@@ -495,7 +497,6 @@ module AncService
         end
 
         result['on_cpt'] = cpt_ids.blank? ? [] : cpt_ids.join(',')
-
         result['arv_before_visit_one'] = b4_visit_one.blank? ? [] : b4_visit_one # .join(",")
 
         result['no_art'] = no_art.join(',')
@@ -1079,12 +1080,9 @@ module AncService
       # end
 
       def on_art_before_anc_final_visit
-        ids = begin
-          @c_on_art_before
-        rescue StandardError
-          []
-        end
-        (@c_extra_art_checks + ids).uniq
+        (@c_extra_art_checks + @c_on_art_before)&.uniq
+      rescue StandardError
+        []
       end
 
       def start_art_zero_to_twenty_seven_for_final_visit

--- a/app/services/anc_service/reports/cohort_builder.rb
+++ b/app/services/anc_service/reports/cohort_builder.rb
@@ -408,20 +408,6 @@ module AncService
             []
           end
 
-        elsif result = begin
-          Encounter.find_by_sql(['SELECT e.patient_id FROM encounter e
-                                               INNER JOIN obs o on o.encounter_id = e.encounter_id
-                                               WHERE e.voided = 0 AND e.program_id = ? AND e.patient_id IN (?)
-                                               AND e.encounter_type IN (?) AND o.concept_id IN (?)
-                                               AND DATE(e.encounter_datetime) <= ? AND COALESCE(
-                                               (SELECT name FROM concept_name WHERE concept_id = o.value_coded LIMIT 1),
-                                               o.value_text) IN (?)', PROGRAM.id,
-                                 ([0] + @cohort_patients), encounter_types, concept_ids, date,
-                                 art_answers]).map(&:patient_id)
-        rescue StandardError
-          []
-        end
-
         end
 
         result.uniq
@@ -430,7 +416,7 @@ module AncService
       # Returns patient's ART start date at current facility
       def find_patient_date_enrolled(patient)
         order = Order.joins(:encounter, :drug_order)\
-                     .where(encounter: { patient: patient },
+                     .where(encounter: { patient: },
                             drug_order: { drug: Drug.arv_drugs })\
                      .order(:start_date)\
                      .first
@@ -471,47 +457,41 @@ module AncService
         end
 
         result = {}
-        @patient_ids = []
+        patient_ids = []
         b4_visit_one = []
-        no_art = []
+        cpt_ids = []
 
-        art_patients = ActiveRecord::Base.connection.select_all <<~SQL
+        if positive_patients.length.positive?
+          art_patients = ActiveRecord::Base.connection.select_all <<~SQL
             SELECT patient_id, earliest_start_date FROM temp_earliest_start_date
             WHERE gender = 'F' AND death_date IS NULL
             AND patient_id IN (#{positive_patients.join(',')})
-SQL
-        art_patients.each do |patient|
-          @patient_ids << patient['patient_id']
-          earliest_start_date = patient['earliest_start_date'].to_date
-          result[(patient['patient_id']).to_s] = patient['earliest_start_date'].to_date.strftime('%Y-%m-%d')
-          next unless begin
-            earliest_start_date.to_date < anc_visit[patient['patient_id']].to_date
-          rescue StandardError
-            false
-          end
+          SQL
+          art_patients.each do |patient|
+            patient_ids << patient['patient_id']
+            earliest_start_date = patient['earliest_start_date'].to_date
+            result[(patient['patient_id']).to_s] = patient['earliest_start_date'].to_date.strftime('%Y-%m-%d')
+            next unless begin
+              earliest_start_date.to_date < anc_visit[patient['patient_id']].to_date
+            rescue StandardError
+              false
+            end
 
-          b4_visit_one << patient['patient_id']
+            b4_visit_one << patient['patient_id']
+          end
         end
 
         no_art = id_visit_map - result.keys
 
-        dispensing_encounter_type = EncounterType.find_by_name('DISPENSING').id
-        cpt_drug_id = Drug.where(['name LIKE ?', '%Cotrimoxazole%']).map(&:id)
-
-        if @patient_ids.length.positive?
+        if patient_ids.length.positive?
 
           cpt_ids = Encounter.find_by_sql(["SELECT * FROM encounter e
               INNER JOIN obs o ON e.encounter_id = o.encounter_id AND e.voided = 0
 			        WHERE e.encounter_type = (?)
 			        AND o.value_drug IN (?) AND e.patient_id IN (?) AND
-              e.encounter_datetime <= ?", DISPENSING.id, cpt_drug_id.join(','),
-                                           @patient_ids.join(','),
+              e.encounter_datetime <= ?", DISPENSING.id, Drug.where(['name LIKE ?', '%Cotrimoxazole%']).map(&:id).join(','),
+                                           patient_ids.join(','),
                                            date.to_date.end_of_month.strftime('%Y-%m-%d 23:59:59')]).map(&:patient_id)
-
-        else
-
-          cpt_ids = []
-
         end
 
         result['on_cpt'] = cpt_ids.blank? ? [] : cpt_ids.join(',')
@@ -534,12 +514,12 @@ SQL
 
       def start_art_zero_to_twenty_seven_for_first_visit(date)
         remote = []
-        obs = Observation.find_by_sql(["SELECT o.value_datetime, o.person_id FROM obs o
+        Observation.find_by_sql(["SELECT o.value_datetime, o.person_id FROM obs o
             JOIN encounter ON o.encounter_id = encounter.encounter_id
             AND encounter.voided = 0 AND encounter.program_id = ?
             WHERE o.concept_id = ? AND o.person_id IN (?)
             AND DATE(o.obs_datetime) BETWEEN #{@m_lmp} AND ?", PROGRAM.id, LMP.concept_id,
-                                       @total_hiv_positive_first_visit, date.to_date.end_of_month]).collect do |ob|
+                                 @total_hiv_positive_first_visit, date.to_date.end_of_month]).collect do |ob|
           ident = ob.person_id
           # raise ident.inspect
           next unless !ob.value_datetime.blank? && @m_on_art_in_nart[ident.to_s]
@@ -573,7 +553,7 @@ SQL
           if  (start_date >= lmp) && (start_date < (lmp + 28.weeks)) && !remote.include?(ob.person_id)
             remote << ob.person_id
           end
-        end # rescue []
+        end
 
         remote = [] if remote.to_s.blank?
 
@@ -582,12 +562,12 @@ SQL
 
       def start_art_plus_twenty_eight_for_first_visit(date)
         remote = []
-        obs = Observation.find_by_sql(["SELECT o.value_datetime, o.person_id FROM obs o
+        Observation.find_by_sql(["SELECT o.value_datetime, o.person_id FROM obs o
             JOIN encounter ON o.encounter_id = encounter.encounter_id
             AND encounter.voided = 0 AND encounter.program_id = ?
             WHERE o.concept_id = ? AND o.person_id IN (?)
             AND DATE(o.obs_datetime) BETWEEN #{@m_lmp} AND ?", PROGRAM.id, LMP.concept_id,
-                                       @total_hiv_positive_first_visit, date.to_date.end_of_month]).collect do |ob|
+                                 @total_hiv_positive_first_visit, date.to_date.end_of_month]).collect do |ob|
           ident = ob.person_id
           # raise ident.inspect
           next unless !ob.value_datetime.blank? && @m_on_art_in_nart[ident.to_s]
@@ -621,7 +601,7 @@ SQL
           # rescue []
           # raise ident.inspect
           remote << ob.person_id if start_date >= (lmp + 28.weeks) && !remote.include?(ob.person_id)
-        end # rescue []
+        end
 
         remote = [] if remote.to_s.blank?
 
@@ -730,7 +710,6 @@ SQL
 
       def patients_given_fefol_tablets
         fefol = {}
-        minus_120 = []
         plus_120 = []
         Order.joins([[drug_order: :drug], :encounter])
              .where(["encounter.program_id = ? AND drug.name = ? AND (DATE(encounter_datetime) >= #{@c_lmp}
@@ -762,13 +741,13 @@ SQL
 
       def patients_given_one_albendazole_dose
         Order.joins([[drug_order: :drug], :encounter])
-                    .where(["encounter.program_id = ? AND drug.name LIKE ? AND (DATE(encounter_datetime) >= #{@c_lmp}
+             .where(["encounter.program_id = ? AND drug.name LIKE ? AND (DATE(encounter_datetime) >= #{@c_lmp}
                     AND DATE(encounter_datetime) <= ?) AND encounter.patient_id IN (?)", PROGRAM.id,
-                            '%albendazole%', (@c_start_date.to_date + @c_pregnant_range), @cohort_patients])
-                    .select(["encounter.patient_id, encounter.encounter_id, drug.name instructions,
+                     '%albendazole%', (@c_start_date.to_date + @c_pregnant_range), @cohort_patients])
+             .select(["encounter.patient_id, encounter.encounter_id, drug.name instructions,
                     SUM(DATEDIFF(orders.auto_expire_date, orders.start_date)) orderer"])
-                    .group('encounter.patient_id')
-                    .pluck(:patient_id)
+             .group('encounter.patient_id')
+             .pluck(:patient_id)
       end
 
       def patients_not_given_bed_net
@@ -1110,12 +1089,12 @@ SQL
 
       def start_art_zero_to_twenty_seven_for_final_visit
         remote = []
-        obs = Observation.find_by_sql(["SELECT o.value_datetime, o.person_id FROM obs o
+        Observation.find_by_sql(["SELECT o.value_datetime, o.person_id FROM obs o
             JOIN encounter ON o.encounter_id = encounter.encounter_id
             WHERE o.concept_id = ? AND o.person_id IN (?)
             AND DATE(o.obs_datetime) BETWEEN #{@c_lmp} AND ?", LMP.concept_id,
-                                       @c_total_hiv_positive, ((@c_start_date.to_date + @c_pregnant_range) - 1.day)])
-                         .collect do |ob|
+                                 @c_total_hiv_positive, ((@c_start_date.to_date + @c_pregnant_range) - 1.day)])
+                   .collect do |ob|
           ident = ob.person_id
           # raise ident.inspect
           next unless !ob.value_datetime.blank? && @c_on_art_in_nart[ident.to_s]
@@ -1158,7 +1137,7 @@ SQL
           if  (start_date >= lmp) && (start_date < (lmp + 28.weeks)) && !remote.include?(ob.person_id)
             remote << ob.person_id
           end
-        end # rescue []
+        end
 
         remote = [] if remote.to_s.blank?
 
@@ -1167,12 +1146,12 @@ SQL
 
       def start_art_plus_twenty_eight_for_final_visit
         remote = []
-        obs = Observation.find_by_sql(["SELECT o.value_datetime, o.person_id FROM obs o
+        Observation.find_by_sql(["SELECT o.value_datetime, o.person_id FROM obs o
             JOIN encounter ON o.encounter_id = encounter.encounter_id
             WHERE o.concept_id = ? AND o.person_id IN (?)
             AND DATE(o.obs_datetime) BETWEEN #{@c_lmp} AND ?", LMP.concept_id,
-                                       @c_total_hiv_positive, ((@c_start_date.to_date + @c_pregnant_range) - 1.day)])
-                         .collect do |ob|
+                                 @c_total_hiv_positive, ((@c_start_date.to_date + @c_pregnant_range) - 1.day)])
+                   .collect do |ob|
           ident = ob.person_id
           # raise ident.inspect
           next unless !ob.value_datetime.blank? && @c_on_art_in_nart[ident.to_s]
@@ -1215,7 +1194,7 @@ SQL
           # rescue []
           # raise ident.inspect
           remote << ob.person_id if start_date >= (lmp + 28.weeks) && !remote.include?(ob.person_id)
-        end # rescue []
+        end
 
         remote = [] if remote.to_s.blank?
 


### PR DESCRIPTION
### Issue

When Searching for ANC positive patients in NART, the query uses a *IN ()* expression to query only those listed as positive

when no positive patient is found in ANC, the system was throwing a mysql error

```SQL
SELECT patient_id, earliest_start_date FROM temp_earliest_start_date
WHERE gender = 'F' AND death_date IS NULL
AND patient_id IN ()

Completed 500 Internal Server Error in 81661ms (ActiveRecord: 81380.7ms | Allocations: 99744)

ActiveRecord::StatementInvalid (Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ")" at line 3)
```


### Resolution

- Skip query if length <= 0

### Other Changes Made

- Extra checks in the codebase for similar cases and update
- Format Code with rubocop
- Remove unused variables