### PR TITLE
fix: remove breaking to hash method

### DIFF
--- a/app/services/hts_service/reports/hts_report_builder.rb
+++ b/app/services/hts_service/reports/hts_report_builder.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Style/Documentation, Style/MultilineBlockChain
+# rubocop:disable Style/Documentation, Style/MultilineBlockChain, Layout/LineLength, Metrics/AbcSize, Metrics/ModuleLength, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/BlockLength, Metrics/ParameterLists
 # frozen_string_literal: true
 
 module HtsService
@@ -163,7 +163,7 @@ class ObsValueScopeRevised
         ObsValueScope.call(model: query, name: indicator[:name], \
                            concept: indicator[:concept], value: indicator[:value] || 'value_coded', \
                            join: indicator[:join], max: indicator[:max]).select('person.gender, person.person_id, person.birthdate, encounter.encounter_datetime, person.person_id').group(:patient_id).to_sql
-      ).to_hash
+      )
     end.flat_map { |arr| arr }
               .group_by { |hash| hash['person_id'] }
               .transform_values { |group| group.reduce(&:merge) }
@@ -217,4 +217,4 @@ class ObsValueScope
   end
 end
 
-# rubocop:enable Style/Documentation, Style/MultilineBlockChain
+# rubocop:enable Style/Documentation, Style/MultilineBlockChain, Layout/LineLength, Metrics/AbcSize, Metrics/ModuleLength, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/BlockLength, Metrics/ParameterLists


### PR DESCRIPTION
## Context
- active record select all method does not support to_hash method in ruby >= 3

## Changes in the codebase
- Remove referencing to hash method on select all block

## Ticket
[Link](https://app.shortcut.com/egpaf-2/story/3274/hts-reports-not-able-to-generate)