### PR TITLE
fix: printing of patient history label

### DIFF
--- a/app/services/anc_service/patient_history_label.rb
+++ b/app/services/anc_service/patient_history_label.rb
@@ -199,7 +199,7 @@ module AncService
         0
       end
 
-      label = ZebraPrinter::StandardLabel.new
+      label = ZebraPrinter::Lib::StandardLabel.new
 
       label.draw_text('Obstetric History', 28, 8, 0, 1, 1, 2, false)
       label.draw_text('Medical History', 400, 8, 0, 1, 1, 2, false)


### PR DESCRIPTION
## Context
*Error when printing Patient history label.*

## Changes in the codebase
*Update class definition of the zebra printing label*

## Ticket
[Link](https://app.shortcut.com/egpaf-2/story/3332/fix-error-printing-patient-history-label)