### PR TITLE
(# 4117) Fix crashing visit summary

### DIFF
--- a/app/services/art_service/patient_visit_label.rb
+++ b/app/services/art_service/patient_visit_label.rb
@@ -37,7 +37,6 @@ module ArtService
                                                                   "(PC:#{pill_count[0..24]})"
                                                                 end}", 25, 95, 0, 2, 1, 1, false
       )
-
       label.draw_text('SE', 25, 130, 0, 3, 1, 1, false)
       label.draw_text('TB', 110, 130, 0, 3, 1, 1, false)
       label.draw_text('Adh', 185, 130, 0, 3, 1, 1, false)
@@ -120,7 +119,7 @@ module ArtService
       over_100_done = false
       below_100_done = false
 
-      adherence_data.each_value do |adh|
+      adherence_data.each do |_drug, adh|
         next if adh.blank?
 
         drug_adherence = adh.to_i


### PR DESCRIPTION
# Issue
* App crashing because of undefined each_value

# Pull request which caused issue
https://github.com/HISMalawi/BHT-EMR-API/pull/574

# Shortcut
https://app.shortcut.com/egpaf-2/story/4117/print-visit-summary-not-working-on-2024q2-release
