### PR TITLE
Dde connection bugfix

### DIFF
--- a/lib/dde_client.rb
+++ b/lib/dde_client.rb
@@ -61,7 +61,7 @@ class DdeClient
     LOGGER.debug 'Loading DDE connection'
     if connection[:expires] < Time.now
       LOGGER.debug 'DDE connection expired'
-      establish_connection(connection[:config])
+      establish_connection(**connection[:config])
     else
       @base_url = connection[:config][:url]
       connection
@@ -120,7 +120,7 @@ class DdeClient
     return handle_response e.response unless @auto_login
 
     LOGGER.debug 'Auto-logging into DDE...'
-    establish_connection(@connection[:config])
+    establish_connection(**@connection[:config])
     LOGGER.debug "Reset connection: #{@connection}"
     retry # Retry last request...
   rescue RestClient::BadRequest => e


### PR DESCRIPTION
## Context
This fix is to address the problem where DDE is not available after a day or two.

## Description
This was caused by when the token expires the api service was supposed to reconnect to the DDE service and the parameters were not splatted for the the method.

## Changes in the codebase
Just splatted the two calls to the method.

## Changes outside the codebase


## Aditional information


## Ticket


## Screenshots
