### PR TITLE
Fix: Reverted drill response to use person_id

### DIFF
--- a/app/services/art_service/reports/art_cohort.rb
+++ b/app/services/art_service/reports/art_cohort.rb
@@ -85,7 +85,7 @@ module ArtService
 
         ActiveRecord::Base.connection.select_all <<~SQL
           SELECT i.identifier arv_number, p.birthdate,
-                 p.gender, n.given_name, n.family_name, p.person_id patient_id,
+                 p.gender, n.given_name, n.family_name, p.person_id person_id,
                  outcomes.cum_outcome AS outcome, tesd.earliest_start_date art_start_date
           FROM person p
           INNER JOIN cohort_drill_down c ON c.patient_id = p.person_id

--- a/app/services/art_service/reports/cohort_builder.rb
+++ b/app/services/art_service/reports/cohort_builder.rb
@@ -753,6 +753,7 @@ module ArtService
           AND o.obs_datetime < (DATE('#{end_date}') + INTERVAL 1 DAY) AND e.voided = 0
           WHERE e.voided = 0
           GROUP BY o.person_id
+          HAVING value_datetime IS NOT NULL
         SQL
       end
 

--- a/app/services/art_service/reports/tpt_outcome.rb
+++ b/app/services/art_service/reports/tpt_outcome.rb
@@ -396,7 +396,9 @@ module ArtService
             report[patient['age_group']][patient[@param]][:completed_tpt_new] << @common_response if new_on_art
             report[patient['age_group']][patient[@param]][:completed_tpt_prev] << @common_response unless new_on_art
           else
-            report[patient['age_group']][patient[@param]][:not_completed_tpt] << @common_response
+            if patient_on_art(patient)
+              report[patient['age_group']][patient[@param]][:not_completed_tpt] << @common_response
+            end
             process_outcomes report, patient
           end
         end
@@ -409,7 +411,9 @@ module ArtService
           if patient_completed_tpt?(patient, patient['tpt_type'])
             report[patient['age_group']][patient[@param]][:completed_tpt] << @common_response
           else
-            report[patient['age_group']][patient[@param]][:not_completed_tpt] << @common_response
+            if patient_on_art(patient)
+              report[patient['age_group']][patient[@param]][:not_completed_tpt] << @common_response
+            end
             process_outcomes report, patient
           end
         end
@@ -457,6 +461,10 @@ module ArtService
           report[patient['age_group']][patient[@param]][condition] << @common_response
           @condition = true
         end
+      end
+
+      def patient_on_art(patient)
+        patient['outcome'] == 'On antiretrovirals'
       end
 
       def patient_new_on_art?(patient)


### PR DESCRIPTION
### About
- This PR resolves shortcut issue number [4330](https://app.shortcut.com/egpaf-2/story/4330/emc-cohort-report-drildown-not-brining-the-client-mastercard-when-a-client-is-clicked)