### PR TITLE
Feat/metadata sync script

### DIFF
--- a/bin/metadata/remap.rb
+++ b/bin/metadata/remap.rb
@@ -185,7 +185,19 @@ def update_tx_tables
       column = c[:column]
       ref = c[:ref]
 
-      ref = "temp_remap_#{ref}"
+      ref_table = "temp_remap_#{ref}"
+
+      # Check if mapping table exists before updating
+      table_exists = MasterBase.connection.select_value(
+        "SELECT COUNT(*) FROM information_schema.tables 
+         WHERE table_schema = '#{masterdb}' 
+         AND table_name = '#{ref_table}'"
+      ).to_i > 0
+
+      unless table_exists
+        log("Skipping #{table}.#{column} - no mapping table for #{ref}")
+        next
+      end
 
       log("Updating #{column} for table #{table}")
       sql = <<~SQL
@@ -198,7 +210,7 @@ def update_tx_tables
           SELECT old_id FROM %<masterdb>s.%<ref>s
         )#{'      '}
       SQL
-      formatted = format(sql, table:, column:, ref:, masterdb:)
+      formatted = format(sql, table:, column:, ref: ref_table, masterdb:)
       SlaveBase.connection.execute(formatted)
     end
   end

--- a/bin/metadata/remap.rb
+++ b/bin/metadata/remap.rb
@@ -185,19 +185,7 @@ def update_tx_tables
       column = c[:column]
       ref = c[:ref]
 
-      ref_table = "temp_remap_#{ref}"
-
-      # Check if mapping table exists before updating
-      table_exists = MasterBase.connection.select_value(
-        "SELECT COUNT(*) FROM information_schema.tables 
-         WHERE table_schema = '#{masterdb}' 
-         AND table_name = '#{ref_table}'"
-      ).to_i > 0
-
-      unless table_exists
-        log("Skipping #{table}.#{column} - no mapping table for #{ref}")
-        next
-      end 
+      ref = "temp_remap_#{ref}"
 
       log("Updating #{column} for table #{table}")
       sql = <<~SQL
@@ -210,7 +198,7 @@ def update_tx_tables
           SELECT old_id FROM %<masterdb>s.%<ref>s
         )#{'      '}
       SQL
-      formatted = format(sql, table:, column:, ref: ref_table, masterdb:)
+      formatted = format(sql, table:, column:, ref:, masterdb:)
       SlaveBase.connection.execute(formatted)
     end
   end

--- a/bin/metadata/remap.rb
+++ b/bin/metadata/remap.rb
@@ -197,7 +197,7 @@ def update_tx_tables
       unless table_exists
         log("Skipping #{table}.#{column} - no mapping table for #{ref}")
         next
-      end
+      end 
 
       log("Updating #{column} for table #{table}")
       sql = <<~SQL


### PR DESCRIPTION
# Metadata Merge Script

This script merges two OpenMRS databases by combining their metadata and transactional tables. Here's how it works:

1. Creates a new database
2. Loads the master metadata into the new database
3. For each metadata table:
   - Selects data from slave table that doesn't exist in master (using UUID)
   - Inserts the data into the master table
   - Creates a temp_mapping table to track mappings between slave and master tables
   - Dumps the master metadata into the slave database
4. For each transactional table:
   - Updates the transactional table to use the new UUIDs from the temp_mapping table

## Usage

### Pre-requisites

1. Add the following to your `database.yml`:
   - A `metadata_server_local` database configuration that points to the local metadata database that will be created
     - This database will be created by the script.
    ```yaml
    metadata_server_local:
      <<: *default  
      database: <openmrs_metadata>
    ```

   - A `metadata_server` database configuration that points to the remote metadata database that has the latest metadata
    ```yaml
    metatata_server:
      <<: *default
      database: <lts_metadata_database>
    ```

### Usage

- Run the script:
    ```bash
    rails runner bin/metadata/remap.rb
    ```

