### PR TITLE
fix: check if mapping table exists before updating transactional tables

### DIFF
--- a/bin/metadata/remap.rb
+++ b/bin/metadata/remap.rb
@@ -185,7 +185,19 @@ def update_tx_tables
       column = c[:column]
       ref = c[:ref]
 
-      ref = "temp_remap_#{ref}"
+      ref_table = "temp_remap_#{ref}"
+
+      # Check if mapping table exists before updating
+      table_exists = MasterBase.connection.select_value(
+        "SELECT COUNT(*) FROM information_schema.tables 
+         WHERE table_schema = '#{masterdb}' 
+         AND table_name = '#{ref_table}'"
+      ).to_i > 0
+
+      unless table_exists
+        log("Skipping #{table}.#{column} - no mapping table for #{ref}")
+        next
+      end
 
       log("Updating #{column} for table #{table}")
       sql = <<~SQL
@@ -198,7 +210,7 @@ def update_tx_tables
           SELECT old_id FROM %<masterdb>s.%<ref>s
         )#{'      '}
       SQL
-      formatted = format(sql, table:, column:, ref:, masterdb:)
+      formatted = format(sql, table:, column:, ref: ref_table, masterdb:)
       SlaveBase.connection.execute(formatted)
     end
   end


### PR DESCRIPTION
### Issue
- The metadata remapping script was failing because it tried to update transactional tables using temporary mapping tables that didn't always exist. When there were no differences between master and slave metadata for a particular table (like drug), no mapping table was created, but the script still attempted to use it, causing a "table doesn't exist" error.

### Fix
- The fix adds a simple check to verify the mapping table exists before running updates, allowing the script to skip tables gracefully when there's no mapping data and continue processing the